### PR TITLE
Make suggest_backports use string version comparison

### DIFF
--- a/suggest_backports.py
+++ b/suggest_backports.py
@@ -293,12 +293,12 @@ class GithubSuggestBackports(object):
         tags = sorted(self.get_tags(),
                       key=lambda t: pkg_resources.parse_version(t['name']),
                       reverse=True)
+        branch_base_ver_name = self.branch.lstrip('v').rstrip('.x')
+
         # Get the last tag that should be in this branch
         for tag in tags:
-            tag_ver = pkg_resources.parse_version(tag['name'].lstrip('v'))
-            branch_base_ver = branch_ver[:branch_ver.index('*x')]
-            cmp_indx = len(branch_base_ver)
-            if tag_ver[:cmp_indx] == branch_ver[:cmp_indx]:
+            tag_ver_name = tag['name'].lstrip('v')
+            if tag_ver_name.startswith(branch_base_ver_name):
                 self._last_tag = tag
                 break
         else:


### PR DESCRIPTION
This is an adjustment to the suggest_backports script to resolve an error both @astrofrog and I were encountering.  I've included the traceback at the end of what we currently both see in master.  

It looks to me like what's changed is that the ``pkg_resources.parse_version`` function used to return a rather strangely-formatted tuple to allow comparison to work, but now (where "now" is defined as "yesterday on @astrofrog and my machines") it's a custom object with method-level comparison implementations.  But that makes the stuff in `get_last_tag` fail because it's no longer iterable.  So this PR just changes that to instead use direct string comparison to determine if a tag and a branch are the same.  Look right to you, @embray ?

```
Traceback (most recent call last):
  File "suggest_backports.py", line 459, in <module>
    sys.exit(main(sys.argv[1:]))
  File "suggest_backports.py", line 428, in main
    for pr, sha in suggester.iter_suggested_prs():
  File "suggest_backports.py", line 330, in iter_suggested_prs
    last_tag_commit = self.get_last_tag_commit()
  File "suggest_backports.py", line 313, in get_last_tag_commit
    last_tag = self.get_last_tag()
  File "suggest_backports.py", line 299, in get_last_tag
    branch_base_ver = branch_ver[:branch_ver.index('*x')]
AttributeError: 'SetuptoolsLegacyVersion' object has no attribute 'index'
```