### PR TITLE
Add tool to search affiliated packages

### DIFF
--- a/astropy_grep_affiliated
+++ b/astropy_grep_affiliated
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, unicode_literals, print_function
+
+import six
+from six.moves.urllib.request import urlopen
+from six.moves.urllib.parse import urlencode
+
+import json
+import sys
+import webbrowser
+
+
+def get_registry():
+    req = urlopen("http://astropy.org/affiliated/registry.json")
+    return json.load(req)
+
+
+def search_astropy_affiliated_packages(args):
+    search_string = ' '.join(args)
+
+    registry = get_registry()
+    repos = []
+    for package in registry['packages']:
+        repo_url = package.get('repo_url', '')
+        if repo_url.startswith('http://github.com/'):
+            if repo_url.endswith('.git'):
+                repo_url = repo_url[:-4]
+            repos.append('repo:' + repo_url[len('http://github.com/'):])
+
+    query = ' '.join(repos + [search_string])
+
+    url = 'http://github.com/search?' + urlencode({
+        'q': query,
+        'type': 'Code'})
+
+    print(url)
+
+    webbrowser.open(url)
+
+
+if __name__ == '__main__':
+    if len(sys.argv) == 1 or '--help' in sys.argv:
+        print("Searches for a string across all affiliated packages on github, ")
+        print("and opens the results in the default webbrowser.")
+        print()
+        print("Usage: astropy_grep_affiliated [SEARCH STRING]")
+        sys.exit(0)
+
+    search_astropy_affiliated_packages(sys.argv[1:])


### PR DESCRIPTION
Replaces astropy/astropy#3629.

In trying to answer some questions about the usage of the configuration package among affiliated packages, I found this tool to be pretty useful.

```
./astropy_grep_affiliated ConfigItem
```

opens the following URL:

https://github.com/search?q=repo%3Aastropy%2Fspecutils+repo%3Aastropy%2Fastroquery+repo%3Aastropy%2Fphotutils+repo%3Aeteq%2Fastropysics+repo%3Aejeschke%2Fg+repo%3AastroML%2Fast+repo%3Aweaverba137%2Fpydl+repo%3Aaplpy%2Faplpy+repo%3Agammapy%2Fgammapy+repo%3Aastropy%2Fccdproc+repo%3Asncosmo%2Fsnc+repo%3Aspacetelescope%2Fim+ConfigItem&type=Code

Thought it might be useful...  wasn't exactly sure where to put it, so put it under a new `devtools` directory.  I could also just share it as a gist if it doesn't belong in the repo.