### PR TITLE
Add a setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,43 @@
+# Compiled files
+*.py[cod]
+*.a
+*.o
+*.so
+*.pyd
+__pycache__
+
+# Other generated files
+MANIFEST
+
+# Packages/installer info
+*.egg
+*.egg-info
+dist
+build
+eggs
+.eggs
+parts
+bin
+var
+sdist
+develop-eggs
+.installed.cfg
+distribute-*.tar.gz
+
+# Other
+.cache
+.tox
+.*.swp
+*~
+.project
+.pydevproject
+.settings
+.coverage
+cover
+htmlcov
+
+# Mac OSX
+.DS_Store
+
+# PyCharm
+.idea

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,0 +1,26 @@
+Copyright (c) 2011-2015, Astropy Developers
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+* Neither the name of the Astropy Team nor the names of its contributors may be
+  used to endorse or promote products derived from this software without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/astropy_grep_affiliated.py
+++ b/astropy_grep_affiliated.py
@@ -41,7 +41,7 @@ def search_astropy_affiliated_packages(args):
     webbrowser.open(url)
 
 
-if __name__ == '__main__':
+def main():
     if len(sys.argv) == 1 or '--help' in sys.argv:
         print("Searches for a string across all affiliated packages on github, ")
         print("and opens the results in the default webbrowser.")
@@ -50,3 +50,7 @@ if __name__ == '__main__':
         sys.exit(0)
 
     search_astropy_affiliated_packages(sys.argv[1:])
+
+
+if __name__ == '__main__':
+    main()

--- a/gh_issuereport.py
+++ b/gh_issuereport.py
@@ -22,9 +22,12 @@ Requires the requests package (https://pypi.python.org/pypi/requests/).
 
 """
 
+import argparse
 import os
 import json
 import datetime
+
+from getpass import getpass
 
 import requests
 
@@ -133,10 +136,8 @@ def get_datetime_of_pypi_version(pkg, version):
 
     return datetime.datetime.strptime(datestr, "%Y-%m-%d")
 
-if __name__ == '__main__':
-    import argparse
-    from getpass import getpass
 
+def main(argv=None):
     parser = argparse.ArgumentParser(description='Process some integers.')
     parser.add_argument('repo', help='the github repo to use')
     parser.add_argument('package', help='the package/version to lookup on pypi '
@@ -149,7 +150,7 @@ if __name__ == '__main__':
                                                  "the cached versions)",
                                             dest='cache', action='store_false')
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
     if args.package.lower() == 'none':
         # probably nothing on github was created before the year 1900...
         pkgdt = datetime.datetime(1900, 1, 1)
@@ -178,3 +179,7 @@ if __name__ == '__main__':
     print(icnt['opened'], 'issues opened since', args.package, 'and', icnt['closed'], 'issues closed')
     print(prcnt['opened'], 'PRs opened since', args.package, 'and', prcnt['merged'], 'PRs merged')
     print(prcnt['usersopened'], 'unique users opened PRs, and', prcnt['usersmerged'], 'of them got it merged')
+
+
+if __name__ == '__main__':
+    main()

--- a/issue2pr.py
+++ b/issue2pr.py
@@ -9,6 +9,9 @@ project.
 
 from __future__ import print_function
 
+import argparse
+import sys
+
 
 def issue_to_pr(issuenum, srcbranch, repo='astropy', targetuser='astropy',
                 targetbranch='master', username=None, pw=None,
@@ -100,15 +103,10 @@ def _add_basic_auth_header(req, username, pw):
     req.add_header('Authorization', 'Basic ' + upwstrenc)
 
 
-if __name__ == '__main__':
-    import sys
-
+def main(argv=None):
     if sys.version_info < (2,6):
         print('issue2pr.py requires Python >=2.6, exiting')
         sys.exit(-1)
-
-
-    import argparse
 
     descr = 'Convert a github issue to a Pull Request by attaching code.'
     parser = argparse.ArgumentParser(description=descr)
@@ -133,7 +131,7 @@ if __name__ == '__main__':
                         default='https://api.github.com', help='The base '
                         'URL for github (default: https://api.github.com)')
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     targrepo = args.targetuser + '/' + args.repo
 
@@ -142,3 +140,7 @@ if __name__ == '__main__':
           args.repo, 'repo to branch', args.targbranch, 'of ', targrepo)
     issue_to_pr(args.issuenum, args.srcbranch, args.repo, args.targetuser,
                 args.targbranch, None, None, args.baseurl)
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+from setuptools import setup
+
+
+URL_BASE = 'https://github.com/astropy/astropy-tools/'
+
+
+setup(
+    name='astropy-tools',
+    version='0.0.0.dev0',
+    author='The Astropy Developers',
+    author_email='astropy.team@gmail.com',
+    url=URL_BASE,
+    download_url=URL_BASE + 'archive/master.zip',
+    classifiers=[
+        'Development Status :: 2 - Pre-Alpha',
+        'Environment :: Console',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: BSD License',
+        'Natural Language :: English',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.4',
+        'Topic :: Software Development',
+        'Topic :: Utilities'
+    ],
+    py_modules=['gitastropyplots'],
+    scripts=[
+        'gh_issuereport.py',
+        'issue2pr.py',
+        'suggest_backports.py'
+    ]
+)
+

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
             'issue2pr = issue2pr:main',
             'suggest_backports = suggest_backports:main'
         ]
-    }
+    },
+    install_requires=['requests']
 )
 

--- a/setup.py
+++ b/setup.py
@@ -29,13 +29,15 @@ setup(
         'gitastropyplots',
         'gh_issuereport',
         'issue2pr',
-        'suggest_backports'
+        'suggest_backports',
+        'astropy_grep_affiliated'
     ],
     entry_points={
         'console_scripts': [
             'gh_issuereport = gh_issuereport:main',
             'issue2pr = issue2pr:main',
-            'suggest_backports = suggest_backports:main'
+            'suggest_backports = suggest_backports:main',
+            'astropy_grep_affiliated = astropy_grep_affiliated:main'
         ]
     },
     install_requires=['requests']

--- a/setup.py
+++ b/setup.py
@@ -25,11 +25,18 @@ setup(
         'Topic :: Software Development',
         'Topic :: Utilities'
     ],
-    py_modules=['gitastropyplots'],
-    scripts=[
-        'gh_issuereport.py',
-        'issue2pr.py',
-        'suggest_backports.py'
-    ]
+    py_modules=[
+        'gitastropyplots',
+        'gh_issuereport',
+        'issue2pr',
+        'suggest_backports'
+    ],
+    entry_points={
+        'console_scripts': [
+            'gh_issuereport = gh_issuereport:main',
+            'issue2pr = issue2pr:main',
+            'suggest_backports = suggest_backports:main'
+        ]
+    }
 )
 

--- a/suggest_backports.py
+++ b/suggest_backports.py
@@ -390,7 +390,7 @@ def get_credentials():
 
     return username, password
 
-def main(argv):
+def main(argv=None):
     parser = argparse.ArgumentParser(
         description='Find pull requests that need be backported to a bug fix '
                     'branch')


### PR DESCRIPTION
This is mostly just for convenience--this doesn't mean we would package or distribute astropy-tools.

But this way I can just clone astropy-tools and run:

```
$ ./setup.py develop
```

and get links to the latest versions of the tools in this repository installed into whatever environment I want to have them in.  Use of this is of course totally optional.

Also added a license.