### PR TITLE
Issue2pr requests

### DIFF
--- a/issue2pr.py
+++ b/issue2pr.py
@@ -119,8 +119,8 @@ def main(argv=None):
                         default='master', help='The branch name the pull '
                         'request should be pulled into (default: master)')
     parser.add_argument('--baseurl', metavar='URL', type=str,
-                        default='https://api.github.com', help='The base '
-                        'URL for github (default: https://api.github.com)')
+                        default=GH_API_BASE_URL, help='The base '
+                        'URL for github (default: %(default)s)')
 
     args = parser.parse_args(argv)
 

--- a/issue2pr.py
+++ b/issue2pr.py
@@ -13,7 +13,7 @@ import argparse
 import getpass
 import json
 import sys
-import urllib
+
 
 try:
     import requests
@@ -22,6 +22,14 @@ except ImportError:
           '`pip install requests`, or your package manager of choice.',
           file=sys.stderr)
     sys.exit(1)
+
+
+if sys.version_info[0] >= 3:
+    # Define raw_input on Python 3
+    raw_input = input
+    from urllib.parse import urljoin as basejoin
+else:
+    from urllib import basejoin
 
 
 GH_API_BASE_URL = 'https://api.github.com'
@@ -89,7 +97,7 @@ def issue_to_pr(issuenum, srcbranch, repo='astropy', targetuser='astropy',
     datajson = json.dumps(data)
 
     suburl = 'repos/{user}/{repo}/pulls'.format(user=targetuser, repo=repo)
-    url = urllib.basejoin(baseurl, suburl)
+    url = basejoin(baseurl, suburl)
     res = requests.post(url, data=datajson, auth=auth)
     return res.json()
 


### PR DESCRIPTION
This builds on #3, but also could be separated out.  It brings two enhancements to the issue2pr.py script:

1) It now uses the requests module to interact with the GH API.  This makes the code almost trivial.  It's not a big deal to have requests installed, and #3 also requires it.  

2) This change in turn makes it trivial to fix the script to work on Python 3, since requests works on Python 3.  Now I don't have to keep running 
```
$ python2.7 `which issue2pr.py`
```
just to use this script ;)