### PR TITLE
Remove username and password from doctring in issue_to_pr

### DIFF
--- a/issue2pr.py
+++ b/issue2pr.py
@@ -57,13 +57,6 @@ def issue_to_pr(issuenum, srcbranch, repo='astropy', targetuser='astropy',
     targetbranch : str
         The name of the branch (in `targetuser`/`repo`) that the pull request
         should merge into.
-    username : str or None
-        The name of the user sourcing the pull request.  If None, the caller
-        will be prompted for their name at the terminal.
-    pw : str or None
-        The password of the user sourcing the pull request.  If None, the
-       caller will be prompted for their name at the terminal (text will be
-       hidden).
    baseurl : str
        The URL to use to access the github site (including protocol).
 


### PR DESCRIPTION
The two arguments where removed from the function a few days ago, but the arguments are still in the docstring.

@embray