### PR TITLE
Scripts to check changelog consistency

### DIFF
--- a/changelog/1.get_merged_prs.py
+++ b/changelog/1.get_merged_prs.py
@@ -1,3 +1,10 @@
+# The purpose of this script is to download information about all pull requests
+# merged into the master branch of the astropy repository. This information is
+# downloaded to a JSON file. This includes the 'last modified' date for all pull
+# requests, so that when the script is re-run, only modified or new entries are
+# downloaded. At this time, this script requires the developer version of the
+# pygithub package.
+
 import os
 import json
 
@@ -10,10 +17,11 @@ from common import get_credentials
 def parse_isoformat(string):
     return datetime.strptime(string, "%Y-%m-%dT%H:%M:%S")
 
+REPOSITORY = 'astropy/astropy'
 
+# Get handle to repository
 g = Github(*get_credentials())
-
-repo = g.get_organization('astropy').get_repo('astropy')
+repo = g.get_repo(REPOSITORY)
 
 # We continue from an existing file rather than starting from scratch. To start
 # from scratch, just remove the JSON file
@@ -22,6 +30,9 @@ if os.path.exists('merged_pull_requests.json'):
         pull_requests = json.load(merged)
 else:
     pull_requests = {}
+
+# We enclose the following code in a try...finally so that if the updating
+# crashes, we still write out what we had.
 
 try:
 

--- a/changelog/1.get_merged_prs.py
+++ b/changelog/1.get_merged_prs.py
@@ -1,0 +1,59 @@
+import os
+import json
+
+from datetime import datetime
+from github import Github
+
+from common import get_credentials
+
+
+def parse_isoformat(string):
+    return datetime.strptime(string, "%Y-%m-%dT%H:%M:%S")
+
+
+g = Github(*get_credentials())
+
+repo = g.get_organization('astropy').get_repo('astropy')
+
+# We continue from an existing file rather than starting from scratch. To start
+# from scratch, just remove the JSON file
+if os.path.exists('merged_pull_requests.json'):
+    with open('merged_pull_requests.json') as merged:
+        pull_requests = json.load(merged)
+else:
+    pull_requests = {}
+
+try:
+
+    for pr in repo.get_pulls(state='closed', sort='updated', direction='desc', base='master'):
+
+        if not pr.merged:
+            continue
+
+        if str(pr.number) in pull_requests:
+            if pr.updated_at > parse_isoformat(pull_requests[str(pr.number)]['updated']):
+                print("Updating entry for pull request #{0}".format(pr.number))
+            else:
+                break
+        else:
+            print("Fetching new entry for pull request #{0}".format(pr.number))
+
+        if pr.milestone is None:
+            milestone = None
+        else:
+            milestone = pr.milestone.title
+
+        # Get labels
+        issue = repo.get_issue(pr.number)
+        labels = [label.name for label in issue.labels]
+
+        pull_requests[str(pr.number)] = {'milestone': milestone,
+                                         'title': pr.title,
+                                         'labels': labels,
+                                         'merged': pr.merged_at.isoformat(),
+                                         'updated': pr.updated_at.isoformat()}
+
+finally:
+
+    with open('merged_pull_requests.json', 'w') as f:
+        json.dump(pull_requests, f, sort_keys=True, indent=2)

--- a/changelog/1.get_merged_prs.py
+++ b/changelog/1.get_merged_prs.py
@@ -62,7 +62,8 @@ try:
                                          'title': pr.title,
                                          'labels': labels,
                                          'merged': pr.merged_at.isoformat(),
-                                         'updated': pr.updated_at.isoformat()}
+                                         'updated': pr.updated_at.isoformat(),
+                                         'merge_commit': pr.merge_commit_sha}
 
 finally:
 

--- a/changelog/2.find_pr_branches.py
+++ b/changelog/2.find_pr_branches.py
@@ -1,4 +1,12 @@
+# The purpose of this script is to check all the maintenance branches of the
+# core astropy repository, and find which pull requests are included in which
+# branches. The output is a JSON file that contains for each pull request the
+# list of all branches in which it is included. We look specifically for the
+# message "Merge pull request #xxxx " in commit messages, so this is not
+# completely foolproof, but seems to work for now.
+
 import os
+import json
 import subprocess
 import tempfile
 from collections import defaultdict
@@ -12,10 +20,10 @@ TMPDIR = tempfile.mkdtemp()
 STARTDIR = os.path.abspath('.')
 
 # The branches we are interested in
-BRANCHES = ['v0.1.x', 'v0.2.x', 'v0.3.x', 'v0.4.x', 'v1.0.x', 'v1.1.x', 'v1.2.x']
+BRANCHES = ['v0.1.x', 'v0.2.x', 'v0.3.x', 'v0.4.x',
+            'v1.0.x', 'v1.1.x', 'v1.2.x']
 
 # Read in a list of all the PRs
-import json
 with open('merged_pull_requests.json') as merged:
     merged_prs = json.load(merged)
 

--- a/changelog/2.find_pr_branches.py
+++ b/changelog/2.find_pr_branches.py
@@ -1,0 +1,60 @@
+import os
+import subprocess
+import tempfile
+from collections import defaultdict
+
+from astropy.utils.console import color_print
+
+REPOSITORY = 'git://github.com/astropy/astropy.git'
+NAME = os.path.basename(REPOSITORY).replace('.git', '')
+
+TMPDIR = tempfile.mkdtemp()
+STARTDIR = os.path.abspath('.')
+
+# The branches we are interested in
+BRANCHES = ['v0.1.x', 'v0.2.x', 'v0.3.x', 'v0.4.x', 'v1.0.x', 'v1.1.x', 'v1.2.x']
+
+# Read in a list of all the PRs
+import json
+with open('merged_pull_requests.json') as merged:
+    merged_prs = json.load(merged)
+
+# Set up a dictionary where each key will be a PR and each value will be a list
+# of branches in which the PR is present
+pr_branches = defaultdict(list)
+
+try:
+
+    # Set up repository
+    color_print('Cloning {0}'.format(REPOSITORY), 'green')
+    os.chdir(TMPDIR)
+    subprocess.call('git clone {0}'.format(REPOSITORY), shell=True)
+    os.chdir(NAME)
+
+    # Loop over branches and find all PRs in the branch
+    for branch in BRANCHES:
+
+        # Change branch
+        color_print('Switching to branch {0}'.format(branch), 'green')
+        subprocess.call('git reset --hard', shell=True)
+        subprocess.call('git clean -fxd', shell=True)
+        subprocess.call('git checkout {0}'.format(branch), shell=True)
+
+        # Extract entire log
+        log = subprocess.check_output('git log --first-parent', shell=True).decode('utf-8')
+
+        # Check for the presence of the PR in the log
+        for pr in merged_prs:
+            count = log.count("Merge pull request #{0} ".format(pr))
+            if count == 0:
+                pass  # not in branch
+            else:
+                pr_branches[pr].append(branch)
+                if count > 1:
+                    color_print("Pull request {0} appears {1} times in branch {2}".format(pr, count, branch), 'red')
+
+finally:
+    os.chdir(STARTDIR)
+
+with open('pull_requests_branches.json', 'w') as f:
+    json.dump(pr_branches, f, sort_keys=True, indent=2)

--- a/changelog/3.find_pr_changelog_section.py
+++ b/changelog/3.find_pr_changelog_section.py
@@ -1,0 +1,48 @@
+import re
+import os
+import json
+import zipfile
+import tempfile
+import subprocess
+
+import requests
+
+CHANGELOG = 'https://raw.githubusercontent.com/astropy/astropy/master/CHANGES.rst'
+TMPDIR = tempfile.mkdtemp()
+
+BLOCK_PATTERN = re.compile('\[#.+\]', flags=re.DOTALL)
+ISSUE_PATTERN = re.compile('#[0-9]+')
+
+
+def find_prs_in_changelog(content):
+    issue_numbers = []
+    for block in BLOCK_PATTERN.finditer(content):
+        block_start, block_end = block.start(), block.end()
+        block = content[block_start:block_end]
+        for m in ISSUE_PATTERN.finditer(block):
+            start, end = m.start(), m.end()
+            issue_numbers.append(block[start:end][1:])
+    return issue_numbers
+
+# Get all the PR numbers from the changelog
+
+changelog_prs = {}
+version = None
+content = ''
+previous = None
+
+for line in requests.get(CHANGELOG).text.splitlines():
+    if '-------' in line:
+        if version is not None:
+            for pr in find_prs_in_changelog(content):
+                changelog_prs[pr] = version
+        version = previous.strip().split('(')[0].strip()
+        if not 'v' in version:
+            version = 'v' + version
+        content = ''
+    elif version is not None:
+        content += line
+    previous = line
+
+with open('pull_requests_changelog_sections.json', 'w') as f:
+    json.dump(changelog_prs, f, sort_keys=True, indent=2)

--- a/changelog/3.find_pr_changelog_section.py
+++ b/changelog/3.find_pr_changelog_section.py
@@ -1,9 +1,11 @@
+# The purpose of this script is to search through the latest changelog to find
+# for each pull request what section of the changelog the pull request is
+# mentioned in. The output is a JSON file that contains for each pull request
+# the changelog section.
+
 import re
-import os
 import json
-import zipfile
 import tempfile
-import subprocess
 
 import requests
 
@@ -37,7 +39,7 @@ for line in requests.get(CHANGELOG).text.splitlines():
             for pr in find_prs_in_changelog(content):
                 changelog_prs[pr] = version
         version = previous.strip().split('(')[0].strip()
-        if not 'v' in version:
+        if 'v' not in version:
             version = 'v' + version
         content = ''
     elif version is not None:

--- a/changelog/4.check_consistency.py
+++ b/changelog/4.check_consistency.py
@@ -1,0 +1,168 @@
+import re
+import os
+import json
+from datetime import datetime
+import subprocess
+
+from astropy.utils.console import color_print
+
+def parse_isoformat(string):
+    return datetime.strptime(string, "%Y-%m-%dT%H:%M:%S")
+
+# Only consider PRs merged after this date/time. At the moment, this is the date
+# and time at which the v1.0.x branch was created.
+START = parse_isoformat('2015-01-27T16:22:59')
+
+SHOW_VALID = False
+VALID = 'green'
+CANTFIX = 'yellow'
+INVALID = 'red'
+BRANCHES = ['v0.1.x', 'v0.2.x', 'v0.3.x', 'v0.4.x', 'v1.0.x', 'v1.1.x', 'v1.2.x']
+
+BRANCH_CLOSED = {
+    'v0.1.x': '2012-06-19T02:09:53',
+    'v0.2.x': '2013-10-25T12:29:58',
+    'v0.3.x': '2014-05-13T12:06:04',
+    'v0.4.x': '2015-05-29T15:44:38',
+    'v1.0.x': None,
+    'v1.1.x': '2016-03-10T01:09:50',
+    'v1.2.x': None
+}
+
+# TODO: find a more future-proof way of including manual merges
+MANUAL_MERGES = {
+                 '4792':('v1.2.x',),
+                 '4539':('v1.0.x',),
+                 '4423':('v1.2.x',),
+                 '4341':('v1.1.x',),
+                 '4254':('v1.0.x',),
+                 '4719':('v1.2.x',),
+                 '4201':('v1.0.x', 'v1.1.x', 'v1.2.x')
+                 }
+
+EXPECTED_MISSING = {
+                    '4266':('v1.1.x',),  # Forgot to backport to v1.1.x
+                    }
+
+# PRs closed by another PR being merged, so these can be ignored in the
+# consistency checks.
+CLOSED_BY_ANOTHER = {
+                    '3624':'3697',
+                    '2676':'2680'
+                    }
+
+with open('merged_pull_requests.json') as merged:
+    merged_prs = json.load(merged)
+
+with open('pull_requests_changelog_sections.json') as merged:
+    changelog_prs = json.load(merged)
+
+with open('pull_requests_branches.json') as merged:
+    pr_branches = json.load(merged)
+
+for pr in sorted(merged_prs, key=lambda x: int(x)):
+
+    if parse_isoformat(merged_prs[pr]['merged']) < START:
+        continue
+
+    if pr in CLOSED_BY_ANOTHER:
+        continue
+
+    # Extract labels and milestones/versions
+    labels = merged_prs[pr]['labels']
+    milestone = merged_prs[pr]['milestone']
+    if milestone is not None and not milestone.startswith('v') and milestone != 'Future':
+        milestone = 'v' + milestone
+    cl_version = changelog_prs.get(pr, None)
+    branches = pr_branches.get(pr, [])
+
+
+
+    # Check that it appears in the correct version in the changelog
+
+    status = []
+
+    valid = True
+
+    # Check whether affects-dev label is present. If so, the PR should not be
+    # in the changelog.
+
+    if pr in changelog_prs:
+        if 'Affects-dev' in labels:
+            pass
+            # status.append(('Labelled as affects-dev but in changelog ({0})'.format(cl_version), INVALID))
+        elif 'no-changelog-entry-needed' in labels:
+            status.append(('Labelled as no-changelog-entry-needed but in changelog', INVALID))
+        else:
+            if milestone is None:
+                status.append(('In changelog ({0}) but not milestoned'.format(cl_version)))
+            elif milestone.startswith(cl_version):
+                status.append(('In correct section of changelog ({0})'.format(cl_version), VALID))
+            else:
+                status.append(('Milestone is {0} but change log section is {1}'.format(milestone, cl_version), INVALID))
+    else:
+        if 'Affects-dev' in labels:
+            pass
+            # status.append(('Labelled as affects-dev and not in changelog', VALID))
+        elif 'no-changelog-entry-needed' in labels:
+            status.append(('Labelled as no-changelog-entry-needed and not in changelog', VALID))
+        else:
+            if milestone is None:
+                status.append(('Not in changelog (and no milestone) but not labelled affects-dev', INVALID))
+            else:
+                if milestone.startswith('v0.1'):
+                    status.append(('Not in changelog (but ok since milestoned as {0})'.format(milestone), VALID))
+                else:
+                    pass
+                    # status.append(('Not in changelog (milestoned as {0}) but not labelled as affects-dev'.format(milestone), INVALID))
+
+    # Now check for consistency between PR milestone and branch in which the PR
+    # appears - can only check this if the PR milestone is set. If it isn't
+    # set, the above will emit a warning, and once a milestone is then set we
+    # can rerun this and check for errors below.
+
+    if milestone is not None:
+        earliest_expected_branch = milestone[0:4] + '.x'
+
+        if earliest_expected_branch in BRANCHES:
+
+            index = BRANCHES.index(earliest_expected_branch)
+
+            # We now make sure that the PR does NOT appear until ``index``,
+            # then is there all the time.
+
+            for i in range(index):
+                if BRANCHES[i] in branches:
+                    status.append(('Pull request was included in branch {0}'.format(BRANCHES[i]), INVALID))
+                else:
+                    pass  # all good
+
+            for i in range(index, len(BRANCHES)):
+                if BRANCHES[i] in branches:
+                    status.append(('Pull request was included in branch {0}'.format(BRANCHES[i]), VALID))
+                else:
+                    if BRANCHES[i] in MANUAL_MERGES.get(pr,[]):
+                        status.append(('Pull request was included in branch {0} (manually merged)'.format(BRANCHES[i]), VALID))
+                    elif BRANCHES[i] in EXPECTED_MISSING.get(pr, []):
+                        status.append(('Pull request was not included in branch {0} (but whitelisted as ok)'.format(BRANCHES[i]), VALID))
+                    else:
+                        if BRANCH_CLOSED[BRANCHES[i]] is not None:
+                            status.append(('Pull request was not included in branch {0} (but too late to fix)'.format(BRANCHES[i]), CANTFIX))
+                        else:
+                            status.append(('Pull request was not included in branch {0}'.format(BRANCHES[i]), INVALID))
+
+        else:
+            pass  # no branch for this milestone yet
+
+    # If SHOW_VALID is False, we want to skip entries which are all valid.
+    # Otherwise we want to show both valid and invalid entries.
+    if not SHOW_VALID:
+        for msg in status:
+            if 'red' in msg:
+                break
+        else:
+            continue
+
+    print("#{0} (Milestone: {1})".format(pr, milestone))
+    for msg in status:
+        color_print('  - ', '', *msg)

--- a/changelog/4.check_consistency.py
+++ b/changelog/4.check_consistency.py
@@ -30,12 +30,12 @@ BRANCHES = ['v0.1.x', 'v0.2.x', 'v0.3.x', 'v0.4.x', 'v1.0.x', 'v1.1.x', 'v1.2.x'
 # branch.
 
 BRANCH_CLOSED = {
-    'v0.1.x': '2012-06-19T02:09:53',
-    'v0.2.x': '2013-10-25T12:29:58',
-    'v0.3.x': '2014-05-13T12:06:04',
-    'v0.4.x': '2015-05-29T15:44:38',
+    'v0.1.x': parse_isoformat('2012-06-19T02:09:53'),
+    'v0.2.x': parse_isoformat('2013-10-25T12:29:58'),
+    'v0.3.x': parse_isoformat('2014-05-13T12:06:04'),
+    'v0.4.x': parse_isoformat('2015-05-29T15:44:38'),
     'v1.0.x': None,
-    'v1.1.x': '2016-03-10T01:09:50',
+    'v1.1.x': parse_isoformat('2016-03-10T01:09:50'),
     'v1.2.x': None
 }
 
@@ -86,7 +86,9 @@ with open('pull_requests_branches.json') as merged:
 
 for pr in sorted(merged_prs, key=lambda x: int(x)):
 
-    if parse_isoformat(merged_prs[pr]['merged']) < START:
+    merge_date = parse_isoformat(merged_prs[pr]['merged'])
+
+    if merge_date < START:
         continue
 
     if pr in CLOSED_BY_ANOTHER:
@@ -167,7 +169,10 @@ for pr in sorted(merged_prs, key=lambda x: int(x)):
                         status.append(('Pull request was not included in branch {0} (but whitelisted as ok)'.format(BRANCHES[i]), VALID))
                     else:
                         if BRANCH_CLOSED[BRANCHES[i]] is not None:
-                            status.append(('Pull request was not included in branch {0} (but too late to fix)'.format(BRANCHES[i]), CANTFIX))
+                            if merge_date > BRANCH_CLOSED[BRANCHES[i]]:
+                                status.append(('Pull request was not included in branch {0} (but was merged after branch closed)'.format(BRANCHES[i]), VALID))
+                            else:
+                                status.append(('Pull request was not included in branch {0} (but too late to fix)'.format(BRANCHES[i]), CANTFIX))
                         else:
                             status.append(('Pull request was not included in branch {0}'.format(BRANCHES[i]), INVALID))
 

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,20 +1,137 @@
+About
+=====
+
+Scripts
+-------
+
 The scripts in this directory can be used to check for consistency between pull
 request milestones, changelog versions, and which branches pull requests appear
 in. Since some of the steps take a while to run, they are split into multiple
 scripts:
 
-```
-1.get_merged_prs.py
-2.find_pr_branches.py
-3.find_pr_changelog_section.py
-4.check_consistency.py
-```
+* ``1.get_merged_prs.py``
+* ``2.find_pr_branches.py``
+* ``3.find_pr_changelog_section.py``
+* ``4.check_consistency.py``
 
-The first three scripts should be run sequentially. Note that the
-``GITHUB_USER`` and ``GITHUB_PASS`` environment variables should be set for the
-first one to work. These three scripts will produce JSON files which summarize
+The first three scripts should be run sequentially.
+
+The first script requires authentication for GitHub, for which you can either
+use a ``.netrc file``, or you will be prompted for your login details.
+
+These three scripts will produce JSON files which summarize
 the required information.
 
 Once this is done, you can then run ``4.check_consistency.py`` to actually run
 all the consistency checks. Note that this script has a ``SHOW_VALID`` option.
 If set to `False`, this shows only pull requests for which there are issues.
+
+Example
+-------
+
+The following shows an example of a typical session. We start off by updating
+the JSON file so that it is up-to-date with the pull requests merged into
+Astropy:
+
+    $ python 1.get_merged_prs.py 
+    Using the following GitHub credentials from ~/.netrc: username/********
+    Use these credentials (if not you will be prompted for new credentials)? [Y/n] Y
+    Fetching new entry for pull request #5008
+    Fetching new entry for pull request #5010
+    Fetching new entry for pull request #5012
+
+We now run the second script to find out for all pull requests which
+maintenance branches they are included in. Note that this includes some
+preliminary information about issues found at this stage (but these can't
+typically be fixed since it would mean changing the history):
+
+    $ python 2.find_pr_branches.py 
+    Cloning git://github.com/astropy/astropy.git
+    Cloning into 'astropy'...
+    remote: Counting objects: 103101, done.
+    remote: Compressing objects: 100% (13/13), done.
+    remote: Total 103101 (delta 2), reused 0 (delta 0), pack-reused 103088
+    Receiving objects: 100% (103101/103101), 46.26 MiB | 1.71 MiB/s, done.
+    Resolving deltas: 100% (78181/78181), done.
+    Checking connectivity... done.
+    Switching to branch v0.1.x
+    HEAD is now at b97729f Merge pull request #5008 from MSeifert04/docfix
+    Branch v0.1.x set up to track remote branch v0.1.x from origin.
+    Switched to a new branch 'v0.1.x'
+    Switching to branch v0.2.x
+    HEAD is now at 3f2b9eb Merge pull request #291 from mdboom/logging/no-astropy-dir
+    Branch v0.2.x set up to track remote branch v0.2.x from origin.
+    Switched to a new branch 'v0.2.x'
+    Switching to branch v0.3.x
+    HEAD is now at 6d60c3e Back to development: 0.2.6
+    Branch v0.3.x set up to track remote branch v0.3.x from origin.
+    Switched to a new branch 'v0.3.x'
+    Pull request 663 appears 3 times in branch v0.3.x
+    Switching to branch v0.4.x
+    HEAD is now at 4202159 Back to development: 0.3.3
+    Branch v0.4.x set up to track remote branch v0.4.x from origin.
+    Switched to a new branch 'v0.4.x'
+    Pull request 663 appears 3 times in branch v0.4.x
+    Switching to branch v1.0.x
+    HEAD is now at 65444af Back to development: 0.4.7
+    Branch v1.0.x set up to track remote branch v1.0.x from origin.
+    Switched to a new branch 'v1.0.x'
+    Pull request 3766 appears 2 times in branch v1.0.x
+    Pull request 663 appears 3 times in branch v1.0.x
+    Pull request 4228 appears 2 times in branch v1.0.x
+    Switching to branch v1.1.x
+    HEAD is now at 0448e5b Merge pull request #3810 from taldcroft/column-scalar
+    Branch v1.1.x set up to track remote branch v1.1.x from origin.
+    Switched to a new branch 'v1.1.x'
+    Pull request 663 appears 3 times in branch v1.1.x
+    Switching to branch v1.2.x
+    HEAD is now at 955ea32 Merge pull request #4893 from bsipocz/cleanup_changing_log.warn
+    Branch v1.2.x set up to track remote branch v1.2.x from origin.
+    Switched to a new branch 'v1.2.x'
+    Pull request 663 appears 3 times in branch v1.2.x
+
+We then check which sections of the changelog pull requests appear in:
+
+    $ python 3.find_pr_changelog_section.py 
+    
+Note that we now have three JSON files with information from the above three
+scripts:
+
+    $ ls *.json
+    merged_pull_requests.json
+    pull_requests_branches.json
+    pull_requests_changelog_sections.json
+    
+Finally, we run the script to check the consistency of all the information:
+
+    $ python 4.check_consistency.py 
+    #4060 (Milestone: v1.0.10)
+      - Milestone is v1.0.10 but change log section is v1.0.5
+      - Pull request was included in branch v1.0.x
+      - Pull request was included in branch v1.1.x
+      - Pull request was included in branch v1.2.x
+    #4928 (Milestone: v1.2.0)
+      - Labelled as no-changelog-entry-needed and not in changelog
+      - Pull request was not included in branch v1.2.x
+    #4972 (Milestone: v1.0.10)
+      - Labelled as no-changelog-entry-needed and not in changelog
+      - Pull request was not included in branch v1.0.x
+      - Pull request was not included in branch v1.1.x (but too late to fix)
+      - Pull request was not included in branch v1.2.x
+    #4984 (Milestone: v1.2.0)
+      - Labelled as no-changelog-entry-needed and not in changelog
+      - Pull request was not included in branch v1.2.x
+    #4995 (Milestone: v1.2.0)
+      - Labelled as no-changelog-entry-needed and not in changelog
+      - Pull request was not included in branch v1.2.x
+    #4997 (Milestone: v1.2.0)
+      - Labelled as no-changelog-entry-needed and not in changelog
+      - Pull request was not included in branch v1.2.x
+    #5008 (Milestone: v1.0.10)
+      - Labelled as no-changelog-entry-needed and not in changelog
+      - Pull request was not included in branch v1.0.x
+      - Pull request was not included in branch v1.1.x (but too late to fix)
+      - Pull request was not included in branch v1.2.x
+
+If you want to see all results even pull requests that are valid, you can change
+``SHOW_VALID`` to ``True`` in ``4.check_consistency.py ``.

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,0 +1,20 @@
+The scripts in this directory can be used to check for consistency between pull
+request milestones, changelog versions, and which branches pull requests appear
+in. Since some of the steps take a while to run, they are split into multiple
+scripts:
+
+```
+1.get_merged_prs.py
+2.find_pr_branches.py
+3.find_pr_changelog_section.py
+4.check_consistency.py
+```
+
+The first three scripts should be run sequentially. Note that the
+``GITHUB_USER`` and ``GITHUB_PASS`` environment variables should be set for the
+first one to work. These three scripts will produce JSON files which summarize
+the required information.
+
+Once this is done, you can then run ``4.check_consistency.py`` to actually run
+all the consistency checks. Note that this script has a ``SHOW_VALID`` option.
+If set to `False`, this shows only pull requests for which there are issues.

--- a/changelog/common.py
+++ b/changelog/common.py
@@ -1,0 +1,1 @@
+../common.py

--- a/common.py
+++ b/common.py
@@ -1,0 +1,37 @@
+import netrc
+import getpass
+
+GITHUB_API_HOST = 'api.github.com'
+
+
+def get_credentials(username=None, password=None):
+
+    try:
+        my_netrc = netrc.netrc()
+    except:
+        pass
+    else:
+        auth = my_netrc.authenticators(GITHUB_API_HOST)
+        if auth:
+            response = ''
+            while response.lower() not in ('y', 'n'):
+                print('Using the following GitHub credentials from '
+                      '~/.netrc: {0}/{1}'.format(auth[0], '*' * 8))
+                response = input(
+                    'Use these credentials (if not you will be prompted '
+                    'for new credentials)? [Y/n] ')
+            if response.lower() == 'y':
+                username = auth[0]
+                password = auth[2]
+
+    if not (username or password):
+        print("Enter your GitHub username and password so that API "
+              "requests aren't as severely rate-limited...")
+        username = input('Username: ')
+        password = getpass.getpass('Password: ')
+    elif not password:
+        print("Enter your GitHub password so that API "
+              "requests aren't as severely rate-limited...")
+        password = getpass.getpass('Password: ')
+
+    return username, password

--- a/issue2pr.py
+++ b/issue2pr.py
@@ -10,10 +10,10 @@ project.
 from __future__ import print_function
 
 import argparse
-import getpass
 import json
-import netrc
 import sys
+
+from common import get_credentials
 
 try:
     import requests
@@ -93,38 +93,6 @@ def issue_to_pr(issuenum, srcbranch, repo='astropy', sourceuser='',
     url = basejoin(baseurl, suburl)
     res = requests.post(url, data=datajson, auth=(username, password))
     return res.json()
-
-
-def get_credentials(username=None, password=None):
-    try:
-        my_netrc = netrc.netrc()
-    except:
-        pass
-    else:
-        auth = my_netrc.authenticators(GITHUB_API_HOST)
-        if auth:
-            response = ''
-            while response.lower() not in ('y', 'n'):
-                print('Using the following GitHub credentials from '
-                      '~/.netrc: {0}/{1}'.format(auth[0], '*' * 8))
-                response = input(
-                    'Use these credentials (if not you will be prompted '
-                    'for new credentials)? [Y/n] ')
-            if response.lower() == 'y':
-                username = auth[0]
-                password = auth[2]
-
-    if not (username or password):
-        print("Enter your GitHub username and password so that API "
-                 "requests aren't as severely rate-limited...")
-        username = raw_input('Username: ')
-        password = getpass.getpass('Password: ')
-    elif not password:
-        print("Enter your GitHub password so that API "
-                 "requests aren't as severely rate-limited...")
-        password = getpass.getpass('Password: ')
-
-    return username, password
 
 
 def main(argv=None):

--- a/suggest_backports.py
+++ b/suggest_backports.py
@@ -12,11 +12,9 @@ from __future__ import unicode_literals
 
 import argparse
 import base64
-import getpass
 import io
 import json
 import logging
-import netrc
 import os
 import re
 import stat
@@ -39,10 +37,10 @@ except NameError:
 # Because pkg_resources provides better version parsing than distutils
 import pkg_resources
 
+from common import GITHUB_API_HOST, get_credentials
 
 # In principle these should be configurable for projects on enterprise GitHub
 # hosts, but right now we're only using it with the public GitHub.
-GITHUB_API_HOST = 'api.github.com'
 BASE_URL = 'https://{0}/repos/'.format(GITHUB_API_HOST)
 
 # This regex ensures that only the 'Conflicts:' section at the end of the
@@ -418,35 +416,6 @@ class GithubSuggestBackports(object):
                                                compare_master=compare_master):
                     yield pr, merge_commit['sha']
 
-
-def get_credentials():
-    username = password = None
-
-    try:
-        my_netrc = netrc.netrc()
-    except:
-        pass
-    else:
-        auth = my_netrc.authenticators(GITHUB_API_HOST)
-        if auth:
-            response = ''
-            while response.lower() not in ('y', 'n'):
-                log.info('Using the following GitHub credentials from '
-                      '~/.netrc: {0}/{1}'.format(auth[0], '*' * 8))
-                response = input(
-                    'Use these credentials (if not you will be prompted '
-                    'for new credentials)? [Y/n] ')
-            if response.lower() == 'y':
-                username = auth[0]
-                password = auth[2]
-
-    if not (username and password):
-        log.info("Enter your GitHub username and password so that API "
-                 "requests aren't as severely rate-limited...")
-        username = input('Username: ')
-        password = getpass.getpass('Password: ')
-
-    return username, password
 
 def main(argv=None):
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
This is still a work in progress, but the idea is to have a script that can check that milestones in PRs match the changelog and also match which maintenance branch the PR was backported to. At the moment, this just checks that milestones match the changelog section, and there's still some missing logic. I'm just putting this up here to make sure no one else tries to duplicate this effort :)

Example output so far:

```
v1.1.1: 1 out of 5 pull requests had issues:
  Milestone for pull request #4452 is v1.0.8 but is in the changelog section for v1.1.1
v1.1.2: 7 out of 16 pull requests had issues:
  Milestone for pull request #4489 is v1.0.9 but is in the changelog section for v1.1.2
  Milestone for pull request #4514 is v1.0.9 but is in the changelog section for v1.1.2
  Milestone for pull request #4539 is v1.2.0 but is in the changelog section for v1.1.2
  Milestone for pull request #4650 is v1.0.9 but is in the changelog section for v1.1.2
  Milestone for pull request #4468 is v1.0.9 but is in the changelog section for v1.1.2
  Milestone for pull request #4468 is v1.0.9 but is in the changelog section for v1.1.2
  Pull request #4678 is in version v1.1.2 but has no milestone set
v1.1.3: 1 out of 5 pull requests had issues:
  Milestone for pull request #4786 is v1.0.10 but is in the changelog section for v1.1.3
v1.2: 3 out of 69 pull requests had issues:
  Pull request #4671 is in version v1.2 but has no milestone set
  Milestone for pull request #4579 is v1.1.2 but is in the changelog section for v1.2
  Milestone for pull request #4720 is v1.1.3 but is in the changelog section for v1.2
```

* [x] check for PRs that aren't mentioned in the changelog at all (take into account the affects-dev label)
* [x] check which branches a PR has been backported to
* [ ] check for PR numbers mentioned in the changelog and not found on GitHub (although some of those could be issues)
* [x] only check PRs merged into master

cc @eteq