### PR TITLE
Allowing Licence can start at the second line

### DIFF
--- a/clean_parse_tables.py
+++ b/clean_parse_tables.py
@@ -13,6 +13,8 @@ parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument('dir', help='The directory to search through for lextab/parsetab files.')
 args = parser.parse_args()
 
+LICENSE_LINE = "# Licensed under a 3-clause BSD style license - see LICENSE.rst"
+
 for root, dirs, files in os.walk(args.dir):
     for fname in files:
         if not (fname.endswith('lextab.py') or fname.endswith('parsetab.py')):
@@ -24,10 +26,10 @@ for root, dirs, files in os.walk(args.dir):
             lines = fd.readlines()
 
         with open(path, 'wb') as fd:
-            if not (lines[0].startswith("# Licensed under a 3-clause BSD style license - see LICENSE.rst")
-                    or lines[1].startswith("# Licensed under a 3-clause BSD style license - see LICENSE.rst")):
+            if not (lines[0].startswith(LICENSE_LINE)
+                    or lines[1].startswith(LICENSE_LINE)):
                 print('Re-writing license')
-                fd.write("# Licensed under a 3-clause BSD style license - see LICENSE.rst\n")
+                fd.write(LICENSE_LINE + "\n")
                 fd.write("from __future__ import (absolute_import, division, print_function, unicode_literals)\n")
                 fd.write('\n')
 

--- a/clean_parse_tables.py
+++ b/clean_parse_tables.py
@@ -24,7 +24,8 @@ for root, dirs, files in os.walk(args.dir):
             lines = fd.readlines()
 
         with open(path, 'wb') as fd:
-            if not lines[0].startswith("# Licensed under a 3-clause BSD style license - see LICENSE.rst"):
+            if not (lines[0].startswith("# Licensed under a 3-clause BSD style license - see LICENSE.rst")
+                    or lines[1].startswith("# Licensed under a 3-clause BSD style license - see LICENSE.rst")):
                 print('Re-writing license')
                 fd.write("# Licensed under a 3-clause BSD style license - see LICENSE.rst\n")
                 fd.write("from __future__ import (absolute_import, division, print_function, unicode_literals)\n")


### PR DESCRIPTION
There are utf characters in some of the newly generated parsing tables, so the coding was put on the first line making the licence to start on the second.