### PR TITLE
Refactor changelog script to iterate through issues

### DIFF
--- a/changelog/1.get_merged_prs.py
+++ b/changelog/1.get_merged_prs.py
@@ -8,7 +8,7 @@
 import os
 import json
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from github import Github
 
 from common import get_credentials
@@ -18,6 +18,8 @@ def parse_isoformat(string):
     return datetime.strptime(string, "%Y-%m-%dT%H:%M:%S")
 
 REPOSITORY = 'astropy/astropy'
+
+YESTERDAY = datetime(2016, 12, 13, 0, 0, 0)
 
 # Get handle to repository
 g = Github(*get_credentials())
@@ -31,22 +33,50 @@ if os.path.exists('merged_pull_requests.json'):
 else:
     pull_requests = {}
 
+LAST_MODIFIED_DATE = None
+for pr in pull_requests.values():
+    date = parse_isoformat(pr['updated'])
+    if LAST_MODIFIED_DATE is None or date > LAST_MODIFIED_DATE:
+        LAST_MODIFIED_DATE = date
+
+# FIXME: at the moment, because we don't store time zones, to be safe we check
+# for pull requests modified within 24 hours of the cutoff.
+if LAST_MODIFIED_DATE is not None:
+    LAST_MODIFIED_DATE -= timedelta(hours=24)
+
+print("Last modified date: {0}".format(LAST_MODIFIED_DATE))
+
 # We enclose the following code in a try...finally so that if the updating
 # crashes, we still write out what we had.
 
 try:
-    max_issues = repo.get_issues(state='all',sort='created')[0].number
-    i = 0
-    for pr in repo.get_pulls(state='closed', sort='updated', direction='desc', base='master'):
-        i += 1
+
+    # Find the maximum issue number
+    max_issues = repo.get_issues(state='closed', sort='created')[0].number
+
+    # repo.get_pulls doesn't seem to get quite all available pull requests
+    # because state:closed seems to miss some PRs that appear with is:closed
+    # so instead we use get_issues and then get the PR objects manually.
+    # This allows us to also only iterate over issues that have been updated
+    # since a certain time.
+    for i, issue in enumerate(repo.get_issues(since=LAST_MODIFIED_DATE, state='closed')):
+
+        if issue.pull_request is None:
+            continue
+
+        pr = repo.get_pull(issue.number)
+
         if not pr.merged:
+            continue
+
+        if pr.base.ref != 'master':
             continue
 
         if str(pr.number) in pull_requests:
             if pr.updated_at > parse_isoformat(pull_requests[str(pr.number)]['updated']):
                 print("Updating entry for pull request #{} ({} of max {})".format(pr.number, i, max_issues))
             else:
-                break
+                print("Entry for pull request #{} is up to date".format(pr.number, i, max_issues))
         else:
             print("Fetching new entry for pull request #{} ({} of max {})".format(pr.number, i, max_issues))
 

--- a/changelog/1.get_merged_prs.py
+++ b/changelog/1.get_merged_prs.py
@@ -19,7 +19,7 @@ def parse_isoformat(string):
 
 REPOSITORY = 'astropy/astropy'
 
-YESTERDAY = datetime(2016, 12, 13, 0, 0, 0)
+YESTERDAY = datetime.now()-timedelta(1)
 
 # Get handle to repository
 g = Github(*get_credentials())

--- a/changelog/1.get_merged_prs.py
+++ b/changelog/1.get_merged_prs.py
@@ -8,7 +8,7 @@
 import os
 import json
 
-from datetime import datetime, timedelta
+from datetime import datetime
 from github import Github
 
 from common import get_credentials
@@ -18,8 +18,6 @@ def parse_isoformat(string):
     return datetime.strptime(string, "%Y-%m-%dT%H:%M:%S")
 
 REPOSITORY = 'astropy/astropy'
-
-YESTERDAY = datetime.now()-timedelta(1)
 
 # Get handle to repository
 g = Github(*get_credentials())


### PR DESCRIPTION
@eteq - this solves the issues I was seeing, and is cleaner anyway because it allows us to use the ``since`` option in ``get_issues`` to only iterate over issues that have changed since a certain date.