### PR TITLE
Fixing scripts when starting with empty json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # Script generated files
 merged_pull_requests.json
+pull_requests_branches.json
+pull_requests_changelog_sections.json
+consistency.html
 
 # Compiled files
 *.py[cod]

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Script generated files
+merged_pull_requests.json
+
 # Compiled files
 *.py[cod]
 *.a

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Script generated files
-merged_pull_requests.json
-pull_requests_branches.json
-pull_requests_changelog_sections.json
+merged_pull_requests*.json
+pull_requests_branches*.json
+pull_requests_changelog_sections*.json
 consistency.html
 
 # Compiled files

--- a/pr_consistency/1.get_merged_prs.py
+++ b/pr_consistency/1.get_merged_prs.py
@@ -55,6 +55,9 @@ for pr in pull_requests.values():
 # for pull requests modified within 24 hours of the cutoff.
 if LAST_MODIFIED_DATE is not None:
     LAST_MODIFIED_DATE -= timedelta(hours=24)
+else:
+    # With an empty JSON file, we use the date of PR#1
+    LAST_MODIFIED_DATE = datetime(2014, 6, 13, 1, 48, 44)
 
 print("Last modified date: {0}".format(LAST_MODIFIED_DATE))
 

--- a/pr_consistency/4.check_consistency.py
+++ b/pr_consistency/4.check_consistency.py
@@ -59,7 +59,7 @@ BRANCH_CLOSED = {
     'v0.4.x': parse_isoformat('2015-05-29T15:44:38'),
     'v1.0.x': None,
     'v1.1.x': parse_isoformat('2016-03-10T01:09:50'),
-    'v1.2.x': None,
+    'v1.2.x': parse_isoformat('2016-12-23T05:32:04'),
     'v1.3.x': None
 }
 

--- a/pr_consistency/4.check_consistency.py
+++ b/pr_consistency/4.check_consistency.py
@@ -161,8 +161,7 @@ for pr in sorted(merged_prs, key=lambda pr: merged_prs[pr]['merged']):
                 status.append(('Milestone is {0} but change log section is {1}'.format(milestone, cl_version), INVALID))
     else:
         if 'Affects-dev' in labels:
-            pass  # don't print for now since there are too many
-            # status.append(('Labelled as affects-dev and not in changelog', VALID))
+            status.append(('Labelled as affects-dev and not in changelog', VALID))
         elif 'no-changelog-entry-needed' in labels:
             status.append(('Labelled as no-changelog-entry-needed and not in changelog', VALID))
         else:
@@ -172,8 +171,7 @@ for pr in sorted(merged_prs, key=lambda pr: merged_prs[pr]['merged']):
                 if milestone.startswith('v0.1'):
                     status.append(('Not in changelog (but ok since milestoned as {0})'.format(milestone), VALID))
                 else:
-                    pass  # don't print for now since there are too many
-                    # status.append(('Not in changelog (milestoned as {0}) but not labelled as affects-dev'.format(milestone), INVALID))
+                    status.append(('Not in changelog (milestoned as {0}) but not labelled as affects-dev'.format(milestone), INVALID))
 
     # Now check for consistency between PR milestone and branch in which the PR
     # appears - can only check this if the PR milestone is set. If it isn't


### PR DESCRIPTION
This fixes the first script for the case when no json file is present and one has to start from scratch. This closes #27.

Also adding a close date for 1.2.x and the generated json files to gitignore.