### PR TITLE
Fix regex in changelog script

### DIFF
--- a/pr_consistency/3.find_pr_changelog_section.py
+++ b/pr_consistency/3.find_pr_changelog_section.py
@@ -24,7 +24,7 @@ print("The repository this script currently works with is '{}'.\n"
 CHANGELOG = 'https://raw.githubusercontent.com/{}/master/CHANGES.rst'.format(REPOSITORY)
 TMPDIR = tempfile.mkdtemp()
 
-BLOCK_PATTERN = re.compile('\[#[0-9#, ]+\]')
+BLOCK_PATTERN = re.compile('[[(]#[0-9#, ]+[])]')
 ISSUE_PATTERN = re.compile('#[0-9]+')
 
 

--- a/pr_consistency/3.find_pr_changelog_section.py
+++ b/pr_consistency/3.find_pr_changelog_section.py
@@ -24,7 +24,7 @@ print("The repository this script currently works with is '{}'.\n"
 CHANGELOG = 'https://raw.githubusercontent.com/{}/master/CHANGES.rst'.format(REPOSITORY)
 TMPDIR = tempfile.mkdtemp()
 
-BLOCK_PATTERN = re.compile('\[#.+\]', flags=re.DOTALL)
+BLOCK_PATTERN = re.compile('\[#[0-9#, ]+\]')
 ISSUE_PATTERN = re.compile('#[0-9]+')
 
 
@@ -33,12 +33,14 @@ def find_prs_in_changelog(content):
     for block in BLOCK_PATTERN.finditer(content):
         block_start, block_end = block.start(), block.end()
         block = content[block_start:block_end]
+
         for m in ISSUE_PATTERN.finditer(block):
             start, end = m.start(), m.end()
             issue_numbers.append(block[start:end][1:])
     return issue_numbers
 
 # Get all the PR numbers from the changelog
+
 
 changelog_prs = {}
 version = None
@@ -54,6 +56,7 @@ for line in requests.get(CHANGELOG).text.splitlines():
         if 'v' not in version:
             version = 'v' + version
         content = ''
+
     elif version is not None:
         content += line
     previous = line


### PR DESCRIPTION
The current script has the bug that the BLOCK_PATTERN matches the whole set content for a given version number (due to ``[`` and ``]`` falls into the match of ``.+``) rather than just the brackets with the PR/issue number at the end of each entry.

This PR also adds the option that the numbers are listed in parenthesis rather than bracket (see e.g. astroquery).