### PR TITLE
HELPERS_UPDATE: Updating ez_setup.py along with the helpers

### DIFF
--- a/update-affiliated/update_astropy_helpers.py
+++ b/update-affiliated/update_astropy_helpers.py
@@ -85,9 +85,11 @@ def open_pull_request(fork, repo):
         return
     os.chdir('..')
     shutil.copy('astropy_helpers/ah_bootstrap.py', 'ah_bootstrap.py')
+    shutil.copy('astropy_helpers/ez_setup.py', 'ez_setup.py')
 
     run_command('git add astropy_helpers')
     run_command('git add ah_bootstrap.py')
+    run_command('git add ez_setup.py')
     run_command('git commit -m "Updated astropy-helpers to {0}"'.format(HELPERS_TAG))
 
     run_command('git push origin {0}'.format(BRANCH))


### PR DESCRIPTION
While we will remove ez_setup at some point in the near future releases, it would be good to have the latest upgrade propagated to the affiliates before we do that.