### PR TITLE
add notebook on commit distributions

### DIFF
--- a/visualizations_demographics/contributor commit distributions.ipynb
+++ b/visualizations_demographics/contributor commit distributions.ipynb
@@ -1,0 +1,203 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import re\n",
+    "import subprocess\n",
+    "\n",
+    "import numpy as np\n",
+    "\n",
+    "from astropy import modeling, time\n",
+    "\n",
+    "%matplotlib inline\n",
+    "from matplotlib import pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# the path to the astropy source code\n",
+    "astropy_path = os.path.join(os.environ['HOME'], 'src', 'astropy')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First we record the date and SHA of the latest commit to know when this NB applies:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sun Oct 22 15:25:19 2017 -0400\n",
+      "566f82399e1e31a271ba88e41546c8759fc388b1\n"
+     ]
+    }
+   ],
+   "source": [
+    "res = subprocess.run('git log -1 --format=\"%cd\\n%H\" HEAD', shell=True, cwd=astropy_path, check=True, stdout=subprocess.PIPE)\n",
+    "print(res.stdout.decode().strip())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res = subprocess.run('git shortlog HEAD', shell=True, cwd=astropy_path, stdout=subprocess.PIPE)\n",
+    "output = res.stdout.decode()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "name_commits = []\n",
+    "for line in output.split('\\n'):\n",
+    "    match = re.match(r'(.*)\\((\\d+)\\):', line)\n",
+    "    if match:\n",
+    "        name_commits.append((match.group(1).strip(), int(match.group(2))))\n",
+    "name_commit_map = dict(name_commits)    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ncommits = np.fromiter(name_commit_map.values(), dtype=int)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ns, edges = np.histogram(np.log10(ncommits),bins=15)\n",
+    "lns = np.log10(ns)\n",
+    "bincens = (edges[1:] + edges[:-1])/2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.text.Text at 0x114a68fd0>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYsAAAEWCAYAAACXGLsWAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAG59JREFUeJzt3X+UHWWd5/H3xxCkNWgTaTJJoA0qZgdxhmAvBxfGZeBo\nWEcloss6MzJxlpkcnfHXqJHEOa7rnqPgBD3+YsUoaJx11AzEJP6aHAywujMjmhCcIBh/IIF0fgI2\noPRACN/9o54bbi63U7dT3V1V935e5/S5dZ+qW/fbZewP9dRTTykiMDMzO5ynlV2AmZlVn8PCzMxy\nOSzMzCyXw8LMzHI5LMzMLJfDwszMcjkszMwsl8PCzMxyOSzMzCzXUWUXMBGOP/74mDdvXtllmJnV\nyubNm++LiIFOtu2KsJg3bx6bNm0quwwzs1qRtL3Tbd0NZWZmuRwWZmaWy2FhZma5HBZmZpbLYWFm\nZrm6YjTUkVq7ZZgVG7axc2SUOf19LF04n0UL5pZdlplZ5fRsWKzdMszyNVsZ3X8AgOGRUZav2Qrg\nwDAza9Gz3VArNmw7GBQNo/sPsGLDtpIqMjOrrp4Ni50jo+NqNzPrZT0bFnP6+8bVbmbWy3o2LJYu\nnE/f9GmHtPVNn8bShfNLqsjMrLpKDQtJ/ZKuk/RTSXdKeqmkmZJukPTz9HrcZHz3ogVzufyiFzO3\nvw8Bc/v7uPyiF/vitplZG4qI8r5cWgV8PyI+L+lo4BnA+4AHIuIKScuA4yLissPtZ2hoKDyRoJnZ\n+EjaHBFDnWxb2pmFpGcDLwOuAYiIxyJiBLgQWJU2WwUsKqdCMzNrKLMb6mRgH/AFSVskfV7SM4FZ\nEbErbbMbmFVahWZmBpQbFkcBZwCfiYgFwG+BZc0bRNZH1rafTNISSZskbdq3b9+kF2tm1svKDIsd\nwI6IuCW9v44sPPZImg2QXve2+3BErIyIoYgYGhjo6EFPZmZ2hEoLi4jYDdwrqTFW9XzgDmA9sDi1\nLQbWlVCemZk1KXtuqLcBX04joe4C/pwswFZLuhTYDlxcYn1mZkbJYRERtwHthm2dP9W1mJnZ2Hr2\nDm4zM+ucw8LMzHI5LMzMLJfDwszMcjkszMwsl8PCzMxyOSzMzCyXw8LMzHI5LMzMLJfDwszMcjks\nzMwsl8PCzMxyOSzMzCyXw8LMzHI5LMzMLJfDwszMcjkszMwsl8PCzMxyOSzMzCyXw8LMzHI5LMzM\nLJfDwszMcjkszMws11Flfrmku4GHgQPA4xExJGkm8DVgHnA3cHFE/LqsGs3MrBpnFn8YEadHxFB6\nvwzYGBGnABvTezMzK1EVwqLVhcCqtLwKWFRiLWZmRvlhEcB3JW2WtCS1zYqIXWl5NzCrnNLMzKyh\n1GsWwDkRMSzpBOAGST9tXhkRISnafTCFyxKAwcHBya/UzKyHlXpmERHD6XUv8HXgTGCPpNkA6XXv\nGJ9dGRFDETE0MDAwVSWbmfWk0sJC0jMlHdtYBl4B3A6sBxanzRYD68qp0MzMGsrshpoFfF1So45/\niIh/kvQjYLWkS4HtwMUl1mhmZpQYFhFxF/D7bdrvB86f+orMzGwsZY+GMjOzGnBYmJlZLoeFmZnl\ncliYmVkuh4WZmeVyWJiZWS6HhZmZ5XJYmJlZLoeFmZnlcliYmVkuh4WZmeVyWJiZWS6HhZmZ5XJY\nmJlZLoeFmZnlcliYmVkuh4WZmeVyWJiZWa5CYSHp7ZJOT8v/UdJ2Sb+UdObElGdmZlVQ9MziXcA9\nafnDwOeBq4CPFdyvmZlVyFEFPz8zIh6Q1AecCfwR8Djw/sKVmZlZZRQNiwckvRA4DdgUEY9JOgZQ\n8dLMzKwqiobFJ4AtafmS9PoHwB0F92tmZhVyxGEhaRrwz8ACYH9E/Cqt2g4smYDazMysIoqcWTwB\n3AgcGxHRaIyIn41nJyl0NgHDEfEqSTOBrwHzgLuBiyPi1wXqNDOzgo54NFQKiB8DpxSs4R3AnU3v\nlwEbI+IUYGN6b2ZmJSp6zeLbwDckXQ3cS3a2AUBErMn7sKQTyUZQfYhsGC7AhcC5aXkVcDNwWcE6\nzcysgKJh8Rfp9e0t7QHkhgXwceC9wLFNbbMiYlda3g3MKlShmZkVVigsIuJkAEn9wEkRsbXTz0p6\nFbA3IjZLOneM/YekaLdO0hLShfTBwcHxlm5mZuNQdLqPmZLWAw8AP0htr5PUyR3cZwOvkXQ38FXg\nPEn/B9gjaXba12xgb7sPR8TKiBiKiKGBgYEiv4aZmeUoOt3HVWRdRb8DPJbavg+8Ou+DEbE8Ik6M\niHnAG4AbI+KNwHpgcdpsMbCuYI1mZlZQ0WsW5wGDEfFoo7soIvZKOqHAPq8AVku6lOyejYsL1mhm\nZgUVDYt/B/qARxsNkgaA+8ezk4i4mWzUExFxP3B+wbrMzGwCFe2GWgd8VtJzACTNAD4KXF+0MDMz\nq46iZxbLgGvJLkILGAGuA/5nwf3aFFm7ZZgVG7axc2SUOf19LF04n0UL5pZdlplVTNGhs48Ab5D0\nVrLpOe6JiLajl6x61m4ZZvmarYzuPwDA8Mgoy9dko58dGGbWrOjQ2WsBIuK+iNjUCApJn5uI4mxy\nrdiw7WBQNIzuP8CKDdtKqsjMqqroNYvXj9H+uoL7tSmwc2R0XO1m1ruOqBtK0kVpcZqk13Low46e\nT3btwipuTn8fw22CYU5/XwnVmFmVHek1i4+m12M49HnbTwB7gLcVKcqmxtKF8w+5ZgHQN30aSxfO\nL7EqM6uiIwqLpjmhVkeEb5qrqcZFbI+GMrM8RUdDOSjaqNNw1EUL5la2NjOrjnGHhaS3RsSn0/K7\nxtouIjqZTLDreDiqmXWjIzmzeCXw6bQ81oSBwaHXMnrG4YajOizMrK7GHRYR8cqm5T+c2HLqz8NR\nzawbFZ3uA0nTgEEOfdodEfFvRfddRx6OambdqOgd3K8GdgK/BG5r+tlSvLR6WrpwPn3Tpx3S5uGo\nZlZ3Re/g/hTwfuDZwPSmn6ML7re2Fi2Yy+UXvZi5/X0ImNvfx+UXvdjXK8ys1op2Q80APhcRbZ+T\n3as8HNXMuk3RM4trgTdNQB1mZlZhRc8sPgL8QNJSsmdxHxQR5xXct5mZVUTRsPgacB+wHnikeDlm\nZlZFRcPiLOCE9BAkMzPrUkWvWdwOzJyIQszMrLqKnlmsB74l6WqyqckPiog1BfdtZmYVUTQs/jK9\nvrelPQCHhZlZlyg6RfnJR/pZSccA3wOenuq4LiI+IGkm2YXzecDdwMUR8esidZqZWTFFr1kgaZqk\nkyX9XtPPizv46KPAeRHx+8DpwAWSzgKWARsj4hRgY3pvZmYlKnRmkeaG+jww0LIqgGlP/UTTBtld\n379JbxvThARwIXBual8F3AxcVqROMzMrptS5odJZyW3AXuCGiLgFmBURu9Imu4FZBWs0M7OCioZF\nY26ohyPiQPNPJx9O254OnAicKem0lvVBdrbxFJKWSNokadO+ffsK/hpmZnY4lZgbKiJGgJuAC4A9\nkmYDpNe9Y3xmZUQMRcTQwEBrL5iZmU2komHxEeB9ku6QdGPzT94HJQ1I6k/LfcDLgZ+S3buxOG22\nGFhXsEYzMyuozLmhZgOr0pP2ngasjohvSvpXYLWkS4HtwMUFazQzs4JKmxsqPXZ1QZv2+4HzC9Zl\nZmYTyHNDmZlZLs8NZWZmuTw3VE2s3TLMig3b2Dkyypz+PpYunO9Ht5rZlCltbijr3Notwyxfs5XR\n/dntK8MjoyxfsxXAgWFmU6Lw3FANaWJAmwQrNmw7GBQNo/sPsGLDtpIqMrNeUygsJD1d0pWS7gN+\nK+m+9N7BMYF2joyOq93MbKIVPbO4AngZcAlwKvBG4Bzg8oL7tSZz+vvG1W5mNtGKhsXrgNdExHci\nYltE/BPwWuD1xUuzhqUL59M3/dBJfPumT2PpwvklVWRmvaboaKinAw+1tD2U2m2CNC5iezSUmZWl\naFjcBFwj6W8iYnea+O9KsmdQ2ARatGCuw8HMSlO0G+ptwAnATkmPAjvInj/x1qKFmZlZdRS9z2If\ncL6kOWTPpNgRETsnpDIzM6uMoo9VnQuMpoDYmdqOA/ocGmZm3aNoN9Qa4KSWtucC1xfcr5mZVUjR\nsJgfET9uafsx8LsF92tmZhVSdDTUiKRZEdE84+ws4OGC+7Ua86SHZt2n6JnFN4EvSDoJQNIg8Dng\nG0ULs3pqTHo4PDJK8OSkh2u3DJddmpkVUDQslgP/DmxPQ2d/BewHLitamNWTJz00605Fh84+DFwk\n6QSyC9vbI2LvhFRmteRJD826U8dhIWkaMI8nh8oelALCIWHM6e9juE0weNJDs3rrqBtK0tlkd2f/\nDLhX0oikmyR9VNKfSvpdSZrUSq0WPOmhWXfq9MziE8AM4MPAo8BpwEuA/5zWB/Bb4FkTXaDViyc9\nNOtOnYbFqcAVEfG/mhslPRs4gyw4zpjg2qymPOmhWffpNCx2A/taGyPiQbKZZ2+ayKLMzKxaOh06\nuxo4dyK/WNJJ6brHHZJ+IukdqX2mpBsk/Ty9HjeR32tmZuPXaVhcBbxI0p9O4Hc/Drw7Ik4FzgL+\nWtKpwDJgY0ScAmxM783MrESdhsV2YA7wJUnrJP2JpOcV+eKI2BURt6blh4E7gbnAhcCqtNkqYFGR\n7zEzs+I6vWbxMeD09PPq9BOSHgRuBTYDmyNi9ZEUIWkesAC4BZgVEbvSqt1kc021+8wSYAnA4ODg\nkXytmZl1SBExvg9k8z8tIAuOBennJCAiYtrhPjvG/mYA/xf4UESskTQSEf1N638dEYe9bjE0NBSb\nNm0a71ebmfU0SZsjYqiTbcc93UdE3APcA6xr+sKZZKExLpKmkz374ssRsSY175E0OyJ2pWd6+85w\nM7OSFZ1IEICIeCAiNo7nM+mO72uAOyPiY02r1gOL0/JimkLJzMzKUfR5FkWcDVwCbJV0W2p7H3AF\nsFrSpWQX1i8uqT4zM0tKC4uI+H/AWPNJnT+VtZiZ2eFNSDeUmZl1N4eFmZnlcliYmVkuh4WZmeVy\nWJiZWS6HhZmZ5XJYmJlZLoeFmZnlcliYmVkuh4WZmeVyWJiZWa4yJxI0G5e1W4ZZsWEbO0dGmdPf\nx9KF81m0YG7ZZZn1BIeF1cLaLcMsX7OV0f0HABgeGWX5mq0ADgyzKeBuKKuFFRu2HQyKhtH9B1ix\nYVtJFZn1FoeF1cLOkdFxtZvZxHJYWC3M6e8bV7uZTSyHhdXC0oXz6Zs+7ZC2vunTWLpwfkkVmfUW\nX+C2WmhcxPZoKLNyOCysNhYtmOtwMCuJu6HMzCyXw8LMzHI5LMzMLJfDwszMcpUWFpKulbRX0u1N\nbTMl3SDp5+n1uLLqMzOzJ5V5ZvFF4IKWtmXAxog4BdiY3ptNqrVbhjn7ihs5edm3OPuKG1m7Zbjs\nkswqp7SwiIjvAQ+0NF8IrErLq4BFU1qU9ZzGBIXDI6MET05Q6MAwO1TVrlnMiohdaXk3MKvMYqz7\neYJCs85U9qa8iAhJMdZ6SUuAJQCDg4NTVpd1l8maoNDP3rBuU7Uziz2SZgOk171jbRgRKyNiKCKG\nBgYGpqxA6y6TMUGhu7asG1UtLNYDi9PyYmBdibVYD5iMCQrdtWXdqLRuKElfAc4Fjpe0A/gAcAWw\nWtKlwHbg4rLqs94wGRMU+tkb1o1KC4uI+OMxVp0/pYVYz5voCQrn9Pcx3CYY/OwNq7OqdUOZ1Z6f\nvWHdqLKjoczqys/esG7ksDCbBH72hnUbd0OZmVkuh4WZmeVyN5SZ+Y5zy+WwMOtxjTvOGzcSNu44\nBxwYdpC7ocx6nO84t074zMKsRiaju8h3nNdPGd2GDguzmpis7iLfcV4vZXUbuhvKrCYmq7vId5zX\nS1ndhj6zMKuJyeoumqw7zierq6TXR26V1W3osDCricnsLproO84nq6vEI7fK6zZ0N5RZTdSpu2iy\nuko8cqu8fwc+szCriTpNUDhZXSUeuVXevwOHhVmN1GWCwsnqKvHIrUwZ/w7cDWVmE26yukrq1BXX\nbXxmYWYTbrK6SurUFddtFBFl11DY0NBQbNq0qewyzKymenU4rqTNETHUybY+szCznubhuJ3xNQsz\n62kejtsZn1mYWU+bzOG43dS95TMLM+tpYw27LToct9G9NTwySvBk99baLcOF9luWSoaFpAskbZP0\nC0nLyq7HzLrXZA3H7bburcp1Q0maBlwFvBzYAfxI0vqIuKPcysysG03WcNxuu9u8cmEBnAn8IiLu\nApD0VeBCwGFhZpNiMu6I7ra7zavYDTUXuLfp/Y7UZmZWG912t3kVzyw6ImkJsARgcHCw5GrMzA7V\nbXebVzEshoGTmt6fmNoOERErgZWQ3cE9NaWZmXWuLhM/dqKK3VA/Ak6RdLKko4E3AOtLrsnMrKdV\n7swiIh6X9FZgAzANuDYiflJyWWZmPa1yYQEQEd8Gvl12HWZmlqliN5SZmVWMw8LMzHJ1xfMsJO0D\ntrc0Hw/cV0I5E6Gutde1bnDtZahr3VDf2lvrfm5EDHTywa4Ii3Ykber0oR5VU9fa61o3uPYy1LVu\nqG/tRep2N5SZmeVyWJiZWa5uDouVZRdQQF1rr2vd4NrLUNe6ob61H3HdXXvNwszMJk43n1mYmdkE\nqX1Y5D1VT5lPpvX/JumMMups1UHd50p6UNJt6ed/lFFnK0nXStor6fYx1lfyeENHtVf1mJ8k6SZJ\nd0j6iaR3tNmmkse9w9ord9wlHSPph5J+nOr+YJttqnrMO6l9/Mc8Imr7QzZ31C+B5wFHAz8GTm3Z\n5pXAdwABZwG31KTuc4Fvll1rm9pfBpwB3D7G+sod73HUXtVjPhs4Iy0fC/ysDv/Ox1F75Y57Oo4z\n0vJ04BbgrJoc805qH/cxr/uZxcGn6kXEY0DjqXrNLgS+FJkfAP2SZk91oS06qbuSIuJ7wAOH2aSK\nxxvoqPZKiohdEXFrWn4YuJOnPhCskse9w9orJx3H36S309NP6wXeqh7zTmoft7qHRSdP1avik/c6\nrek/pdPb70h60dSUVlgVj/d4VPqYS5oHLCD7r8VmlT/uh6kdKnjcJU2TdBuwF7ghImpzzDuoHcZ5\nzOseFt3sVmAwIn4P+BSwtuR6ekGlj7mkGcD1wDsj4qGy6xmPnNoredwj4kBEnE72ALYzJZ1Wdk2d\n6qD2cR/zuodFJ0/V6+jJe1Mst6aIeKhxKhnZlO3TJR0/dSUesSoe745U+ZhLmk72x/bLEbGmzSaV\nPe55tVf5uANExAhwE3BBy6rKHvOGsWo/kmNe97Do5Kl664E/SyMXzgIejIhdU11oi9y6Jf2OJKXl\nM8n+t7p/yisdvyoe745U9Zinmq4B7oyIj42xWSWPeye1V/G4SxqQ1J+W+4CXAz9t2ayqxzy39iM5\n5pV8+FGnYoyn6kl6c1p/NdlDlF4J/AJ4BPjzsupt6LDu1wNvkfQ4MAq8IdIwhjJJ+grZSIrjJe0A\nPkB2Aa2yx7uhg9orecyBs4FLgK2pHxrgfcAgVP64d1J7FY/7bGCVpGlkf0hXR8Q3q/63Jemk9nEf\nc9/BbWZmuereDWVmZlPAYWFmZrkcFmZmlsthYWZmuRwWZmaWy2FhZma5HBZmZpbLYWGVkubZD0lv\nmsLvPE3S45JePlXfWReSLpT0mKRTyq7FyuWwMIOPAf8cETeUXUjVRMQ6YCvwkbJrsXI5LKynSXop\n2dw5Y825ZPAJ4LVVmTrcyuGwsF73V8B9ZPP8WHtryOY+enPZhVh5HBZWC5KOl3SVpHtTH/q96f1z\n2mw7T9L1kh5KP+tS292Sbm7a7ihgEfDdiNjfZj9Xpusng5KukPQrSaOSNks6Z1J/4QpJU1l/n2zy\nOetRtZ511nqDpGcD/wK8ALiW7MEtC4C3AOdJOjM9spMUHt8HZgFXkz3G8w+Am4Fntuz6JcAM4Idj\nfPUC4EGy5yzfAVwJDADvAa6XdGK7kOlS/woslPQfIqJ1qm7rAQ4Lq4P3AqcAfx0R/7vRmKa8/nRa\n//7UfBnZQ2jeGBFfTm2fkfR3wNKW/Z6aXn85xveeDjwbeHtEfKnpe48C/haYB/z8CH+numkcoxfx\n1Oc6WA9wN5TVwWuBfcDKlvbPpvbXNrW9GtgFfKVl2yvb7HcgvT7QukLSc4GZwLeagyJ5NL2O5lZe\nAekZy28vuJvGg3FOKFqP1ZPDwurgZGBbRDze3Jje/wx4Xsu2v4iIJ1q23QuMtOy38TAXtfnOBen1\nq23WnQY8TMUeoTmWiPgvEfFJgHTd5kiuPTSOkR+A06McFtbL9qXXmW3WnZ5ef9Bm3UuALRV4mttU\nahyjfYfdyrqWw8Lq4C5gfrpWcFB6/8K0vuFu4AWSntay7QlAf8t+b0+v7e5OblzcPuR6Rnq28fPJ\nLrI32p4l6dOStqfRVz+SdFLjeyV9TdJeSTskfVzSMU2fvVvS30q6RdJvJd2YRn6tkHS/pHskveZI\nt0+fuVnSeyT9I9njTP9e0m8kfTGt/5tU+8Pp8+9sczxe0HLMrMc4LKwO1pJdX/iLlva/TO1fb2r7\nBtkziP+4Zdv3tNnvFuAh4Kw26xYAt7Y5ezgjvd7a1PZFsj+mLyULpCU8eT2jce3k+cCZZM+k/nDL\nPt8AXEw2gusZZGczPyW7PvAh4POSphfYHoCI+K/APcAlETEjIt4k6YXpMxdExLHp9/tem+NxFrAn\nIra1WWc9wGFhdfB3ZKOOrpK0UtJbJK0kGwm1La1v+AiwE/iCpE+kbf8B+G9kN98d/OMfEQfIbjg7\nX9LTG+1p+O1JwOY2tRwSFpJmkV1gf3NE7IyIJyJiS0TcJ2kucB7wroh4OCJ2Ah8A3tSyz6sjYnu6\nn2E98HhEXJPq+wpZIA4W2P5wHie7HvEiSc+IiPsiojkIkTSDbPjxP3a4T+tCDgurvIh4kOy/yD8L\nvBL4ZHq9GjincY9F2vY+4Bzgm8B/JwuPY8n+aIunjmD6DNnZwKua2hoXt2/lqV5CdjdzY/joc8n+\nWN/dZtsT07rmC+F3AcdJekZT256m5UeA3S3vSb/DkW4/poi4C7iE7E723ZI2SjqzZbPXkZ3BfLaT\nfVp38n0WVikRcTNtRidFxD6yP2h/1cE+fgVc1NyWzhaeQ9YN07ztDyVtAN4JXJ/avtuuhrSutXtr\nO3CUpHltAmNHWje3KTDmAb+OiEcoxxOtDRFxHXBdupbyXuA6Dj0zeQfw9Yjw9Yoe5jML6zqS+to0\nL0uv7WaWfTfwUkmvGO93RcQeYB1ZF9lsSU+TtEDSc1JA3ARcKWmGpNnAB4FV4/2eCbSH7PoJAJLm\nS3pFOmaPAb8BDjStX0Q2VPiyqS7UqsVnFtaNvi1pO1k30tOA88m6mf6F7GL5ISLiJxT7/8Jisu6u\nHwHPIpti5HVp3Z8AnwJ+RfbH+Hqyu7/L8iHgU5KWp1o+ThZgLyK7nvMTmgYHRMRa4OgS6rSKUW8N\nFbdeIOndwJ+Rdfn0kXUHrQE+2Hx9w8w657AwM7NcvmZhZma5HBZmZpbLYWFmZrkcFmZmlsthYWZm\nuRwWZmaWy2FhZma5HBZmZpbr/wMa7pdMUxT1dAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x114310978>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.scatter(bincens, ns)\n",
+    "plt.xlabel(r'$\\log(n_{\\rm commits})$', fontsize=18)\n",
+    "plt.ylabel(r'$n_{\\rm commiters}$', fontsize=18)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Linear1D(slope=-0.45783104458769275, intercept=1.7621816037292395)>"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZkAAAEWCAYAAAC0Q+rDAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzt3XucVfP6wPHP01Qa1THU6DJJRaUbTZfBiVJJSahcTh3l\nEie55sTUdNw5FMVBKvqR3IVSCJFQJLqrdIZuaEpXkQzdnt8f3zXOnmlPs2fP2rP2zDzv12u/Zu/v\nuj2zGvux1vo+36+oKsYYY0wslAs6AGOMMaWXJRljjDExY0nGGGNMzFiSMcYYEzOWZIwxxsSMJRlj\njDExY0nGGGNMzFiSMcYYEzOWZIwxxsRM+aADCFL16tW1Xr16QYdhjDElxqJFi7apanKk65fpJFOv\nXj0WLlwYdBjGGFNiiMh3hVnfbpcZY4yJGUsyxhhjYsaSjDHGmJgp089kjDH+27t3Lxs2bOD3338P\nOhRTBJUqVaJOnTpUqFChSPuxJGOM8dWGDRuoWrUq9erVQ0SCDsdEQVXZvn07GzZsoH79+kXal90u\nM8b46vfff6datWqWYEowEaFatWq+XI1akjHG+M4STMnn17+h3S6LwrQlWYyamcnGndnUTkokvWtj\neqamBB2WMcbEHbuSKaRpS7IYPnU5WTuzUSBrZzbDpy5n2pKsoEMzxniqVKkS0/3Xq1ePbdu2xfQY\nBdmxYwddunShYcOGdOnShZ9++infdffv309qaio9evTI1T5mzBhOOOEEmjVrxtChQ2MSpyWZQho1\nM5PsvftztWXv3c+omZkBRWSMKYtGjhxJ586d+fbbb+ncuTMjR47Md91HH32UJk2a5Gr76KOPmD59\nOsuWLWPlypXccsstMYnTkkwhbdyZXah2Y0xwVJX09HSaN29OixYtmDx5MgAHDhzg2muv5YQTTqBL\nly50796d119//aDtN23aRPv27WnZsiXNmzdn7ty5B63z8MMP07x5c5o3b84jjzwCwPr16znhhBO4\n5JJLaNKkCRdeeCG//fYbAIsWLaJDhw60bt2arl27smnTpqh+t+nTp3PZZZcBcNlllzFt2rSw623Y\nsIEZM2Zw1VVX5WofP348GRkZHHbYYQAcffTRUcVRkLh5JiMiE4EewBZVbR5meTpwifexPNAESFbV\nHSKyHtgF7Af2qWqbWMVZOymRrDAJpXZSYqwOaUzJddNNsHSpv/ts2RK8L/OCTJ06laVLl7Js2TK2\nbdtG27Ztad++PZ999hnr16/n66+/ZsuWLTRp0oQBAwYctP1LL71E165dufXWW9m/f/+fiSLHokWL\neOaZZ/jiiy9QVU4++WQ6dOjAkUceSWZmJk8//TTt2rVjwIABjBs3jsGDB3PDDTcwffp0kpOTmTx5\nMrfeeisTJ05k1KhRvPjiiwfF0L59ex577LGD2jdv3kytWrUAqFmzJps3bw57Dm666SYefPBBdu3a\nlav9m2++Ye7cudx6661UqlSJ0aNH07Zt24jOa2HETZIBJgGPA8+FW6iqo4BRACJyLvBPVd0RskpH\nVY35TdL0ro0ZPnV5rltmiRUSSO/aONaHNsYU0qeffkrfvn1JSEigRo0adOjQgQULFvDpp59y0UUX\nUa5cOWrWrEnHjh3Dbt+2bVsGDBjA3r176dmzJy1btjxo/7169aJy5coA9O7dm7lz53LeeedxzDHH\n0K5dOwD69evHY489Rrdu3VixYgVdunQB3LOSnESRnp5Oenp6VL+niITtDfb2229z9NFH07p1az7+\n+ONcy/bt28eOHTuYP38+CxYs4OKLL2bt2rW+9wyMmySjqnNEpF6Eq/cFXo5dNPnL6UVmvcuMiUCE\nVxzx4osvvuDqq68G4J577uG8885jzpw5zJgxg8svv5whQ4Zw6aWXRrSvvF/WIoKq0qxZMz7//POD\n1i/oSuaKK65gyZIl1K5dm3feeYcaNWqwadMmatWqxaZNm8Le7vrss8948803eeedd/j999/55Zdf\n6NevHy+88AJ16tShd+/eiAhpaWmUK1eObdu2kZwc8Sj+kVHVuHkB9YAVBaxzOLADOCqkbR2wFFgE\nDCxg+4HAQmBh3bp11Rjjr6+//jroELRy5cqqqjplyhQ966yzdN++fbplyxatW7eubtq0SV999VU9\n55xzdP/+/frjjz/qkUceqa+99tpB+1m/fr3u27dPVVXHjBmjgwcPVlXVY489Vrdu3aqLFi3SFi1a\n6O7du/XXX3/VZs2a6eLFi3XdunUK6Lx581RV9corr9TRo0frH3/8occdd9yf7Xv27NEVK1ZE9Tve\ncsstOmLECFVVHTFihKanpx9y/Y8++kjPOeecPz+PHz9eb7/9dlVVzczM1Dp16uiBAwdybRPu3xJY\nqIX4Xi+JD/7PBT7T3LfKTlPVlsDZwHUi0j6/jVV1gqq2UdU2vmdsY0xc6dWrFyeeeCInnXQSnTp1\n4sEHH6RmzZpccMEF1KlTh6ZNm9KvXz9atWrFEUcccdD2H3/8MSeddBKpqalMnjyZwYMH51reqlUr\nLr/8ctLS0jj55JO56qqrSE1NBaBx48aMHTuWJk2a8NNPP3HNNddQsWJFXn/9dYYNG8ZJJ51Ey5Yt\nmTdvXlS/W0ZGBh988AENGzZk1qxZZGRkALBx40a6d+9e4PYDBgxg7dq1NG/enD59+vDss8/GpIhW\nXGKKD97tsrc1zIP/kHXeAF5T1ZfyWX4X8Kuqji7oeG3atFGbtMwYf61ateqg7rLx6Ndff6VKlSps\n376dtLQ0PvvsM2rWrOnLvtevX0+PHj1YsWKFL/sLSrh/SxFZpIXoXBU3z2QiISJHAB2AfiFtlYFy\nqrrLe38WcE/Mg9m5E5KSYn4YY0xs9OjRg507d7Jnzx5uv/123xKMyS1ukoyIvAycAVQXkQ3AnUAF\nAFV9wlutF/C+qu4O2bQG8IZ3mVceeElV34tpsBs2QNOm8Pe/wx13QO3aMT2cMcZ/eXtb+alevXol\n/irGL3GTZFS1bwTrTMJ1dQ5tWwucFJuo8lGpElx2GTz5JDz3HAweDMOG2ZWNMR5VtUEySzi/HqWU\nxAf/wateHcaMgf/+F3r1gpEjoUEDePBByLbKf1O2VapUie3bt/v2JWWKn3rzyVSqVKnI+4qrB//F\nzbcH/0uXwr/+Be++CykpcNddcPnlUD5uLhSNKTY2M2bpkN/MmIV98G9Jxs/eZZ98AhkZMH8+NG4M\n990HvXuD3TYwxpQShU0ydrvMTx06wLx58MYbUK4cXHghnHwyzJ4ddGTGGBMISzJ+E4GePWH5cpg4\nEX78ETp3hq5dYfHioKMzxphiZUkmVhIS4Ior4Jtv4KGHYOFCaN0a+vSB1auDjs4YY4qFJZlYq1QJ\nhgyBtWvh1lvhrbegSRO45hqIch4JY4wpKSzJFJcjjoB//9tdxQwcCE89Bccf7xLPzz8HHZ0xxsSE\nJZniVqsWjB0Lq1bBeefB/fe7GpvRo8G6fBpjShlLMkE5/nh4+WXXGaBtW0hPh4YN4emnYd++oKMz\nxhhfWJIJWmoqvPee6+ZcuzZcdRWceKLrBl2Ga5iMMaWDJZl40bGjK+KcMgUOHHBFnKeeCjEcxC9a\n05Zk0W7kbOpnzKDdyNlMW5IVdEjGmDhlSSaeiLjksmKF6xiwYYNLPmefDUuWBB0d4BLM8KnLydqZ\njQJZO7MZPnW5JRpjTFiWZOJR+fJw5ZXw7bcwahR88QW0auWmFlizJtDQRs3MJHvv/lxt2Xv3M2pm\nZkARGWPimSWZOBH2FlRiItxyi6uxGT4cpk2DE06A665zIwkEYOPO8KNM59dujCnbLMnEgQJvQSUl\nua7Oa9a4jgFPPgnHHQe3317sNTa1kxIL1W6MKdssycSBiG9B1aoF48e7Gptzz3XFnccdBw8/XGw1\nNuldG5NYISFXW2KFBNK7Ni6W4xtjShZLMnGg0LegGjaEV17533hoN98MjRrBM8/A/v3ht/FJz9QU\nRvRuQUpSIgKkJCUyoncLeqamxPS4xpiSKW6SjIhMFJEtIhJ2YmwROUNEfhaRpd7rjpBl3UQkU0RW\ni0hG8UXtj6hvQbVuDTNnwocfQs2aMGCAq7GZNi2mNTY9U1P4LKMT60aew2cZnSzBGGPyFTdJBpgE\ndCtgnbmq2tJ73QMgIgnAWOBsoCnQV0SaxjRSnxX5FlSnTq4H2uuvu9ECevWCv/7VTaJmjDEBipsk\no6pzgB1RbJoGrFbVtaq6B3gFON/X4GLMl1tQInDBBbByJUyYAN9/D2ecAd27w7JlsQrdGGMOqaRN\nQv9XEfkKyAJuUdWVQArwQ8g6G4CT89uBiAwEBgLUrVs3hqEWTs/UFH9uO5UvD//4B/TrB2PGwIgR\nbuiavn3h3nvdYJzGGFNM4uZKJgKLgbqqeiIwBpgWzU5UdYKqtlHVNsnJyb4GGFcSE2HoUFdjM2yY\nGwvthBPghhtg8+agozPGlBElJsmo6i+q+qv3/h2ggohUx13VHBOyah2vzQAceaS7mlm92nUMGD/e\ndXu+4w745ZegozPGlHIlJsmISE0REe99Gi727cACoKGI1BeRikAf4M3gIo1TtWvDE0/A11/DOef8\n79bZf/4Df/wRdHTGmFIqbpKMiLwMfA40FpENInKliAwSkUHeKhcCK0RkGfAY0EedfcD1wExgFfCq\n96zGhNOoEUyeDAsWuGc1Q4a4tmefjXmNjTGm7BEtw3OWtGnTRhcuXBh0GDE1bUkWo2ZmsnFnNrWT\nEknv2jh3B4NZsyAjAxYtgmbN3PA1557reqsZY0weIrJIVdtEun7cXMkY/0U0LP+ZZ7qrmldfhT17\n4Pzz4fTT4dNPA4vbGFN6WJIpxSIeE00ELrrI1dg8+SSsW+cSTY8esHx5MUZsjCltokoyItJIRHqJ\nyNUiMtB739Dv4EzRFHpMtAoVYOBAN4/NyJHw2Wdw0klw6aUu8RhjTCFFnGREpImIPCoiWbgH7K8D\n44EnvPf/FZGNIvKIiDSJTbimMKIeE+3ww11tzdq1rtbmtdegcWMYPBi2bIlBpMaY0qrAJCMix4nI\n68AK4ErgK+Bu4FKgO3CO9/4eYBlwFa4X2GsiYuXlASrymGhHHumuaFavhiuugLFjXY3NXXfBrl3+\nB2yMKXUK7F0mIn8Ay4FHgamquruA9SvjuhsPBpqqaiWfYvWd9S4rpMxMuO02NxBn9eru/aBBcNhh\n/gZtjIlbhe1dFkmSOU9VoypuFJHzVXV6NNsWh7KQZGJiwQLX7Xn2bKhXD+65B/7+d0hIKHBTY0zJ\n5nsX5mgTjLdt3CYYUwRt27o5bN5/H446ynUMSE2Ft98u0jw205Zk0W7kbOpnzKDdyNm5u1obY0ok\n68Jsoteli7uqmTwZsrNdEWf79q5XWiFFVNNjjClxfEsyInKjiLT03rcVke9EZI03zpgprcqVg4sv\ndmOijR/vOgmcdhqcdx6sCDvJaVgR1/QYY0oUP69khgDfe+/vB57CzVj5sI/HMPGqQgXXCWD1ajc0\nzZw5biroyy6D774rcPNC1/QYY0oEP5PMUaq6Q0QScbNVPgA8AjTz8Rgm3lWuDMOHuxqbW25xt9Ia\nNYKbboKtW/PdLOqaHmNMXPMzyewQkUbA2cBCbyrkioCNtFgWHXUUPPigu7Lp39/N0tmgAdx9d9ga\nmyLX9Bhj4pKfSeZRYAnwPO42GcDpwNc+HsOUNHXqwFNPuXHRzjrLFXIed5xLOnv2/Llaz9QURvRu\nQUpSIgKkJCUyoncLf6akNsYExpeh/kUkAWgN7AT2quo6r70RUFFVI38CXIysTiYAX37pamw++sjV\n2Nx7r6uxKWcdHY0pCYIa6v8AMBv4NifBAKjqN/GaYExA0tJcjc1777lha/r3dzU2M2YUqcbGGBOf\nfEky6i6HlgE2ErMpmAh07QoLF8LLL8Pu3W5agQ4dYN68oKMzxvjIz3sU7wBvicg/ReRCEemd8/Lx\nGKY0KVcO+vRxNTbjxsE330C7dm7itJU2g7YxpYFv0y+LSH4TjqiqFjgas4hMBHoAW1S1eZjllwDD\ncL3VdgHXqOoyb9l6r20/sC/S+4X2TCbO7N4NjzzieqXt2uWGq7n7bjj22KAjM8Z4Apt+WVXr5/OK\ndLj/SUC3QyxfB3RQ1RbAvcCEPMs7qmrLwvzyJs5Urgy33upqbIYMgVdecTU2Q4bAtm1BR2eMiYLv\nXXpE5AgRaVHY7VR1DrDjEMvnqepP3sf5QJ0oQzTxrlo1GD3a3T675BJ49FFXY3PvvfDrr0FHZ4wp\nBD/HLqsmIm8BP+GSACJygYjEYliZK4F3Qz4rMEtEFonIwBgczwShbl2YOBGWL4fOneGOO1yNzeOP\n56qxMcbELz+vZB4HNgE1gZxvgLnAuT4eAxHpiEsyw0KaT1PVlrjRBq4TkfaH2H6giCwUkYVbDzHM\niYkjTZvCG2/A559DkyZwww3u50svwYEDQUdnjDkEP5NMJ+AGVd2Cu7LAe3+0XwcQkRNxA2+er6rb\nc9pVNSvkeG/gxk4LS1UnqGobVW2TnJzsV2imOJxyiivifPddqFrV3Upr1cp9thobY+KSn0nmdyDX\naIYikgxsD7964YhIXWAq0F9VvwlprywiVXPeA2cBVgBaWolAt26weDG8+KLrhda9O5xxBsyfH3R0\nxpg8/Ewy04EnRaQagIhUAR4CpkSysYi8DHwONBaRDSJypYgMEpFB3ip3ANWAcSKyVERy+h7XAD4V\nkWXAl8AMVX3Pv1/LxKVy5dxwNKtWuWc0//0vnHoq9Orl6m6MMXHBzzqZw4GJwEW4WpYDwOvAlaq6\n25eD+MzqZEqRX3/9X43N7t1uHpu77nKdB4wxvgmyTuY3Ve2Du7JIA2qrap94TTCmlKlSBW67zdXY\nDB7sbqU1agQ33wzbfblja4yJgp9dmCcCqOo2VV3oPYRHRP7Pr2MYU6Dq1eHhh+Hbb6FvX3d106AB\n/Pvf7grHGFOs/Hwmc2E+7Rf4eAxjIlO3LjzzDHz1FXTsCLff7mpsxo2zGhtjilGRk0zIIJgJItIr\ndGBMEUnHzTFjTDCaNWPanWO5etBjfFmhOlx3HbuPa+RGf7YaG2NirsgP/kMGxqwLfB+y6ACwGbhP\nVWcU6SAxYg/+S79pS7IYPnU52Xv3gypnrF1IxpznOGHLOmjZEkaMcNMOiM0SbkwkCvvgv3xRD6iq\n9b0Dv6qqFxd1f8b4adTMTJdgAET4+Li2fNKgNZev/5w7F7wCZ5/tamxGjoSTTw40VmNKoyLdLhOR\n60M+fiEiQ8K9ihijMVHbuDP7oDaVckyq387V1owZ4+pqTjkFevd2dTfGGN8U9ZlM95D3PXDjlOV9\n9SjiMYyJWu2kxPzbK1aE66+H1avdvDWzZkHz5nDVVfDDD8UcqTGlU5GSjKp2D3nfMZ9Xp6KHaUx0\n0rs2JrFCQq62xAoJpHdt/L+GqlXdCM9r1sCNN8Lzz0PDhpCeDjvynX3CGBMB3+eTMSae9ExNYUTv\nFqQkJSJASlIiI3q3oGdqysErJyfDf/7j5rHp0wceesjV2Nx/v9XYGBMl34aVARCRBFwvs6qh7ar6\nlW8H8ZH1LjOHtGKFm6nzzTehZk2480648kqoUCHoyIwJTGDDyojIucBGYA2wNOS1xK9jGFOsmjeH\n6dPh00/h+OPhmmvc3DaTJ1uNjTER8vN22RjgduAIoELIq6KPxzCm+LVrB3PmwNtvQ2Kiu5XWti28\n/77NY2NMAfxMMlWA/1PVXaq6P/Tl4zGMCYYInHMOLFkCzz3nOgR07QpnngkLFgQdnTFxy88kMxG4\n3Mf9GRN/EhKgf39XY/Poo7B8OaSlwUUXQWZm0NEZE3f8nE+mGjAf2Av8GLosXrsx24N/U2S7drlR\nn0ePhuxsGDDAdRBICdN7zZhSILAH/8BkYBvwPG6WzNCXMaVT1aouqaxZ4wo7J01ynQSGDYOffgo6\nOmMC5+eVzK/A0ar6my87LAZ2JWN8t369K+x84QU44giXbG68EQ4/POjIjPFFkFcyK4Cjot1YRCaK\nyBYRWZHPchGRx0RktYh8JSKtQpZ1E5FMb1lGtDEYU2T16rmOAcuWwWmnwfDh7srmySdh796gozOm\n2PmZZN4EZojINXnmlOkd4faTgG6HWH420NB7DQTGw58FoGO95U2BviLSNMrfwZiITFuSRbuRs6mf\nMYN2I2czbUlW7hVatIC33oK5c6F+fRg0CJo1g9des27PpkzxM8n8A/gLMBR4KOQ1OpKNVXUOcKiB\nos4HnlNnPpAkIrWANGC1qq5V1T3AK966xsREzhw1WTuzUSBrZzbDpy4/ONGAu5r59FM3akDFinDx\nxa7GZtasYo/bmCD4lmRUtX4+rwY+HSIFCB0ad4PXll+7MTGRa44aT/be/YyamU8XZhE491x3C23S\nJNi6Fbp0cS97JmhKOV8HyBSRBBGpLyInhrxa+HmMohKRgSKyUEQWbt26NehwTAkUbo6aQ7X/KSEB\nLrvMDcD5n//A0qXuqubii12bMaVQcYxdttSnQ2QBx4R8ruO15dcelqpOUNU2qtomOTnZp9BMWXLI\nOWoicdhhcNNNrtvzHXfAO++4MdGuvho2bvQxUmOCV5LGLnsTuNTrZXYK8LOqbgIWAA29K6iKQB9v\nXWNiIqI5aiLxl7+4ydLWrIFrr4VnnmHfccfx/Bl9OemmyeE7FBhTwpT3cV85Y5dF1XVGRF4GzgCq\ni8gG4E5ckkJVnwDewc3EuRr4DbjCW7bPmwZ6JpAATFTVlUX7VYzJX85cNKNmZrJxZza1kxJJ79o4\n/Bw1kahRAx57jPe79OH3f93GJZ9M5rz5bzHu1Iu4a2fPXMc0pqTxsxjzQWCVqj7jyw6LgRVjmnjS\nbuRssnZm02TLWtI/eY5OaxfyY5WjmNTlcjJefQDK+/n/hMZEp7DFmDZ2mSUZEyfqZ8wg9L/GtB9W\nMOzjSbTe+F9o1Ajuuw8uuMD1VjMmIDZ2mTElVN6OA18e05wL+o1iWP973FXMRRe5EZ8//DCgCI0p\nPD+TzClAZ1UdoaqPhr58PIYxpVbYDgUVy3PqPwfAV1/BM8/A5s1uDpuzzoJFiwKK1JjIxc3YZcaU\ndT1TUxjRuwUpSYkIkJKUyIjeLdxD/4QEuPxyV0/z8MOweDG0aQN/+xt8+23QoRuTLz+fyfwL+Bvw\nBLA5dJmqTvXlID6zZzKmxPr5ZzeHzcMPwx9/wFVXuSkHatUKOjJTygX54H9dPovUx6FlfGVJxpR4\nP/4I//63G+W5QgVX5Dl0KCQlBR2ZKaUCe/BfDGOXGWPyqlkTHn/cTQfdqxeMGAENGsCoUW6mTmMC\n5uvYZTlEpFIs9muMycdxx8GLL8KSJXDyye5qpmFDeOop2Lcv6OhMGebn2GWHichoEdkG7BaRbd5n\nSzjGFJeWLeHdd+Gjj6BOHfjHP9zcNlOn2jw2JhB+XsmMBNoD/XGTh/UDTgNG+HgMY0wkzjgDPv8c\n3njDFW9ecAGccgrMnh10ZKaM8TPJXACcp6rvqmqmqr4H9AIu9PEYxphIiUDPnq7GZuJEN8Jz587Q\ntau7rWZMMfAzyRwG/JKn7Rev3RgTlPLl4YorXD3N6NFuorRWraBvX1i9OujoTCnnZ5L5CHhaRGoC\neFMjTwA+9vEYxphoVaoEN98Ma9fCrbe6KaGbNHHTDPz4Y8HbGxMFP5PMDcDRwEYR+QM3DXIN4Hof\nj2GMKaojjnC1NatXu44B//d/rnfabbe5Ik9jfORnncxWVe2Mm5nydOAYVT1TVbf4dQxjjI9q1YJx\n42DVKjjvPDfKc4MG8NBD8PvvQUdnSgk/uzCniMhRqrpRVb9U1Y0icqSI1PbrGMaYGDj+eHj5ZTce\nWtu2cMstrsZm4kSrsTFF5uftsqnAMXnajgWm+HgMY0yspKbCe++5bs61a8OVV8KJJ7pu0GFqbKYt\nyaLdyNnUz5hhU0WbfPmZZBqr6rI8bcuAJj4ewxgTax07wvz5MGUKHDgAvXvDX/8Kn3zy5yrTlmQx\nfOpysnZmo0DWzmyGT11uicYcxM8ks1NEauRpqwHsinQHItJNRDJFZLWIZIRZni4iS73XChHZLyJH\necvWi8hyb5mNemlMUYi45LJihRua5ocfXIHn2WfD0qWMmplJ9t79uTbJ3rufUTMzg4nXxC0/k8zb\nwDMicgyAiNQF/g94K5KNRSQBGAucjRsxoK+INA1dR1VHqWpLVW0JDAc+UdUdIat09JZHPEKoMeYQ\nypd3t82+/dYNuvnFF5CaSvrz93DMzoO7PW/caYNymtz8TDLDgd+B77wuzOuAvcCwCLdPA1ar6lpV\n3QO8Apx/iPX7Ai8XIV5jTKQSE12HgLVrYfhwun07n9n/dzV3fzCe6rt/+nO1vFNIG+NnF+Zdqtob\nqIkbs6yWqvZW1Uhvl6UAP4R83uC1HUREDge6kbtTgQKzRGSRiAws9C9gjClYUhLcfz8fvT2PKS27\ncsmSd/nkyX/wz7kvUP3A76R3bRx0hCbOlI9mI+/WVj0gW1U3hi7z6mJiXRtzLvBZnltlp6lqlogc\nDXwgIv9V1Tl5N/QS0ECAunXrxjhMY0qns89qxbTkCVzy4of0m/EUg+e9wqCvZ3JYrduhyTVudAFj\niOJKRkTa4a4yvgF+EJGdIvKRiDwkIpeISBMRkShiySJ3F+g6Xls4fchzq0xVs7yfW4A3cLffDqKq\nE1S1jaq2SU5OjiJMYwxAz9QUJo++lHNXzYGFCzksrS0MGQKNG8OkSbB/f4H7MKVfNLfLHgWqAPcD\ndwLv4RLCP4HngRVANGNTLAAaikh9EamISyRv5l1JRI4AOgDTQ9oqi0jVnPfAWV4cxpji0Lo1zJwJ\nH34INWq4ATlPPBGmT7d5bMq4aG6XNQVGquo9oY3el38roLX3s1BUdZ+IXA/MBBKAiaq6UkQGecuf\n8FbtBbyvqrtDNq8BvOFdQJUHXvKmGjDG4OpaRs3MZOPObGonJZLetTE9U8M+8iyaTp1cD7QpU9wg\nnD17wqmnwsiR0L69/8czESu2v4E8RAv5fxkishYYparjYxNS8WnTpo0uXGglNaZ0yymcDK1rSayQ\nwIjeLWK/h2LLAAAXwUlEQVT7JbNvHzzzDNx1l5vLpnt3GDHCXeGYYuXn34CILCpMmUg0t8teBc6I\nYjtjTAACK5wsX96N8vztt/DAAzBvnpseun9/WLcutsc2uQRZPBtNkhkLNBORS/wOxhjjv/wKJIut\ncPLww2HoUFdjM3QovP666xxw442weXPxxFDGBfk3EE2S+Q6oDTwnItNF5O8i0sDnuIwxPsmvQLLY\nCyePPNI9m1m92nUMGDfOzWNz553wS95JdY2fgvwbiCbJPAwsBn7C1au8AHwrIjtEZJaIPCAiF/sZ\npDEmeuldG5NYISFXW2KFhOAKJ1NS4MknYeVK95zmnntcsnnkEfjjj2BiKuWC/Bso9IP/XBu78clS\ngZbez1RcrYuqasKhto0H9uDflBVB9SyKyIIFMHy46/5ct65LOv36QULcf4WUKH79DRT2wX+Rkkw+\nARwFpKrqh77uOAYsyRgTR2bNgowMWLQImjWD+++Hc891I0KbuFEcvcsOSVV3lIQEY4yJM2eeCV9+\nCa++Cnv2wPnnw+mnw6efBh2ZKYICk4yIdI525yJyZrTbGmPKoHLl4KKL3POaJ55wPdJOP91d0Sxf\nHnR0JgqRXMm8JyKzRaSHNzDmIYlIBRHpJSKfAO8UPURjTFkybUkW7R6aS/11deg06ClW3pABc+fC\nSSfBpZfC+vXR7dOmig5EJEkmFdiHG0dso4i8KCKDvaTzVxFpJyLnisgQEXkV+BF4HfgN1yHAGGMi\nknda57W/KRce0YEZ0z6F9HR47TVo1AgGD4YtkQ32blNFByviB/8icipwLW4isSq4+VtyrQL8AkwF\nxqvqAh/jjAl78G9MfGk3cjZZYQoEU5IS+SyjE2zY4HqfTZzoJlK7+Wb3qlo1+n2aQonZg39V/VxV\n+wNHAqcAVwIZuJkvBwBtgaNUdUBJSDDGmPhTYGV6nTowYQKsWAFdu8Ldd0ODBvDoo/nW2AQ+4kEZ\nV+jeZaq6X1W/VNVJqjpKVUer6rOqukhVD8QiSGNM2RBxZfoJJ7jhab74Alq0gJtucm3PP3/QPDZx\nM+JBGeV7F2ZjjIlWoSvT09JcEefMmW7YmksvhdRUePvtP+exibsRD8qYQs8nIyKzC1hFgWzge+B9\nYLr6XfFpjCmVcirQC1WZLgJnneXqbF57DW67zXV5Pu00GDmSnu3aFX6fxjfRzCezHkgEcuYu3un9\nTPJ+bsVdIVXDJZzPgLPzTDIWF+zBvzGl0N698PTT7nnNjz+6hHP//dC8edCRlQrFUfHfAdc9eRRQ\nQ1WPUtWjcLNTjvaWpQHVcYNpngbcEcVxjDGm8CpUgEGD3GjP998Pc+a4idIuuwy++y7o6MqcaK5k\n3gB2q2q/fJa/CFRW1Z7e57eAJqp6fFGD9ZtdyRhTBmzf7qYYGDPGPae55ho3NXRycsHbmoMUx5VM\nJ2DuIZbPJffMmbOAOpHsWES6iUimiKwWkYwwy88QkZ9FZKn3uiPSbY0xZVS1ajBqlJuhs39/l2wa\nNHC303btCjq6Ui/a3mUnFLAsdNjUA7iOAIfkDVkzFjgbaAr0FZGmYVadq6otvdc9hdzWGFNWHXMM\nPPWUq7E56yy46y43j82YMW5AThMT0SSZWcA1ItIn7wIR6QsMAj4IaW4FrI9gv2nAalVdq6p7gFdw\nowtEoijbGmPKkiZNYMoUmD/fTSlw441uOugXXoADVurnt2iSzBBcD7IXRWSDiHzsvTbgZsncBtwM\nICKVgGOB5yLYbwrwQ8jnDV5bXn8Vka9E5F0RaVbIbY0xxjn5ZJg9G957D5KS3K201FSYMePPGhtT\ndNFU/H8HnAQ8hBur7GTvtctrO8lbB1X9XVU7qep/fIp3MVBXVU8ExgDTCrsDERkoIgtFZOHWrVt9\nCssYUyKJuOFpFi2Cl1+G3buhRw/o0AHmzQs6ulIhqmcy3sRkQ1W1qaomeq8mXtv2KGPJwk3dnKOO\n1xZ63F9U9Vfv/TtABRGpHsm2IfuYoKptVLVNsvUuMcaAm8emTx/4+msYOxa++QbatXMTp61cGXR0\nJVo8DSuzAGgoIvVFpCLQBze9wJ9EpKaIm4tVRNJw8W+PZFtjjClQxYpw7bWwZg38+9/w8cdubLTL\nL7camyhFlWREpLKI3O09G/nVe30lIneJSOVo9qmq+4DrgZnAKuBVVV0pIoNEZJC32oXAChFZBjwG\n9FEn7LbRxGGMMVSu7Gpp1q6FIUPglVfcPDZDhsC2bUFHV6JEU4x5FK4WpgmuA8A33qJGuKFmVgGn\nq+oOH+OMCSvGNMZE5PvvXZfnZ591CSg9Hf75T6hSJejIil1xFGPeg6uFuR6oraqnq+rpQG3gOqAx\ncFcU+zXGmPhUt66bKG35cujcGe64w9XYPP641dgUIJokcx7wlKqOU9U/J27w5pkZD0wEevoVoDHG\nxI2mTeGNN+Dzz129zQ03uHlsXnzRamzyEU2SqQEsOcTyxd46xhhTOp1yCnz0Ebz7LvzlL9CvH7Rq\n5T5bjU0u0SSZzUDqIZaneusYY0zpJQLdusHixe5KZtcu6N4dOnZ0owkYILok8xZwpYhcLSJ/bi8i\n5URkIDAA6z5sjCkrypWDv/8dVq1yz2hWrYJTT4Vevdz7Mi6aJHMHsBYYB2wUkU9E5BNgIzDeW3an\nfyEaY0wJULEiXHedq7G55x43LXTz5jBgAPzwQ8Hbl1LRDCuzHWgDjMQVQrb1XtuAEUDbIlT9G2NM\nyValCtx+u6uxGTzY3Upr2BBuucXNbVPGFLpOpjSxOhljTMx9/z3ceSc895xLQEOHwk03uXqbEqg4\n6mSMMcZEqm5deOYZ+Oor1yngtttcjc24cbB3b9DRxVyBVzIicmk0O1bVSIb3D5RdyRhjit28eZCR\nAXPnumRz773wt7+5DgQlQGGvZCJJMgcAJfdslwVRVU0oxPqBsCRjjAmEqqupGT7cXeGkpsKIEW7G\nTinMV23xK2ySKR/BOh2LEI8xxpi8RFxNTbdu8NJLrqNAt25wxhkwcqSbUK2UsAf/diVjjAnaH3/A\nhAnu1tnWrdC7N9x3nxuyJs7Yg39jjClpDjvMjYO2Zo0b7fn996FZM7jqKtiwIejoisSSjDHGRGna\nkizajZxN/YwZtBs5m2lLwk7IG7mqVV1357VrXdJ5/nlXYzN0KOyI+9lTwrIkY4wxUZi2JIvhU5eT\ntTMbBbJ2ZjN86vKiJxqA5GR45BHIzISLL4bRo6FBA9c54Lffir7/YmRJxhhjojBqZibZe/fnasve\nu59RMzP9O0i9em6itGXLoH17+Ne/4Pjj4YknSkyNjSUZY4yJwsad2YVqL5IWLeDNN11tTYMGcM01\n7pnNq6/G/Tw2lmSMMSYKtZMSC9Xui9NOc4nmrbdcZ4G//Q3S0uCDD2J3zCKKqyQjIt1EJFNEVotI\nRpjll4jIVyKyXETmichJIcvWe+1LRcT6JRtjYiq9a2MSK+SuOU+skEB618axPbAI9OgBS5e68dC2\nbXNFnGeeCQsWxPbYUYibJCMiCcBY4GygKdBXRJrmWW0d0EFVWwD3AhPyLO+oqi0L04fbGGOi0TM1\nhRG9W5CSlIgAKUmJjOjdgp6pKcUTQEIC9O/vOgc88oh7bpOWBhdd5NriRNwUY4rIqcBdqtrV+zwc\nQFVH5LP+kcAKVU3xPq8H2qjqtkiPacWYxphSY9cueOgh98rOdvPY3HknpPib9EpyMWYKEDqzzwav\nLT9XAu+GfFZglogs8mboDEtEBorIQhFZuHXr1iIFbIwxcaNqVVfIuWaNmzxt0iTXE23YMPjpp8DC\niqckEzER6YhLMsNCmk9T1Za4223XiUj7cNuq6gRVbaOqbZKTk4shWmOMKUZHHw2PPupumV10EYwa\n5XqkPfBAIDU28ZRksoBjQj7X8dpyEZETgaeA80Nn4FTVLO/nFuANIC2m0RpjTDyrX991DFi6FNq1\nc9MLNGzoxkjbt6/YwoinJLMAaCgi9UWkItAHeDN0BRGpC0wF+qvqNyHtlUWkas574CxgRbFFbowx\n8erEE+Htt2HOHFfcecMNkOXDqAQRimSo/2KhqvtE5HpgJpAATFTVlSIyyFv+BHAHUA0YJ27OhX3e\nA6gawBteW3ngJVV9L4Bfwxhj4tPpp8Onn8KqVXDsscV22LjpXRYE611mjDGFU5J7lxljjCllLMkY\nY4yJGUsyxhhjYsaSjDHGmJixJGOMMSZmLMkYY4yJGUsyxhhjYsaSjDHGmJixJGOMMSZmLMkYY4yJ\nGUsyxhhjYsaSjDHGmJixJGOMMSZmLMkYY4yJGUsyxhhjYsaSjDHGmJixJGOMMSZmLMkYY4yJmbhK\nMiLSTUQyRWS1iGSEWS4i8pi3/CsRaRXptsYYU1JMW5JFu5GzqZ8xg3YjZzNtSVbQIUUtbpKMiCQA\nY4GzgaZAXxFpmme1s4GG3msgML4Q2xpjTNybtiSL4VOXk7UzGwWydmYzfOryEpto4ibJAGnAalVd\nq6p7gFeA8/Oscz7wnDrzgSQRqRXhtsYYE/dGzcwke+/+XG3Ze/czamZmQBEVTTwlmRTgh5DPG7y2\nSNaJZFsARGSgiCwUkYVbt24tctDGGOOnjTuzC9Ue7+IpyRQLVZ2gqm1UtU1ycnLQ4RhjTC61kxIL\n1R7v4inJZAHHhHyu47VFsk4k2xpjTNxL79qYxAoJudoSKySQ3rVxQBEVTTwlmQVAQxGpLyIVgT7A\nm3nWeRO41Otldgrws6puinBbY4yJez1TUxjRuwUpSYkIkJKUyIjeLeiZGvYJQNwrH3QAOVR1n4hc\nD8wEEoCJqrpSRAZ5y58A3gG6A6uB34ArDrVtAL+GMcYUWc/UlBKbVPISVQ06hsC0adNGFy5cGHQY\nxhhTYojIIlVtE+n68XS7zBhjTCljScYYY0zMWJIxxhgTM5ZkjDHGxIwlGWOMMTFjScYYY0zMlOku\nzCKyFfguT3N1YFsA4RRVSY0bLPYglNS4oeTGXlLjhtyxH6uqEY/JVaaTTDgisrAwfcDjRUmNGyz2\nIJTUuKHkxl5S44aixW63y4wxxsSMJRljjDExY0nmYBOCDiBKJTVusNiDUFLjhpIbe0mNG4oQuz2T\nMcYYEzN2JWOMMSZmymSSEZFuIpIpIqtFJCPMchGRx7zlX4lIqyDiDCeC2M8QkZ9FZKn3uiOIOPMS\nkYkiskVEVuSzPJ7PeUGxx+s5P0ZEPhKRr0VkpYgMDrNO3J33COOO13NeSUS+FJFlXux3h1kn7s45\nRBx74c+7qpapF26+mTVAA6AisAxommed7sC7gACnAF8EHXchYj8DeDvoWMPE3h5oBazIZ3lcnvMI\nY4/Xc14LaOW9rwp8UxL+1iOMO17PuQBVvPcVgC+AU+L9nBci9kKf97J4JZMGrFbVtaq6B3gFOD/P\nOucDz6kzH0gSkVrFHWgYkcQel1R1DrDjEKvE6zmPJPa4pKqbVHWx934XsArIOxNW3J33COOOS955\n/NX7WMF75X3wHXfnHCKOvdDKYpJJAX4I+byBg/+AI1knCJHG9VfvMvxdEWlWPKEVWbye80jF9TkX\nkXpAKu7/TkPF9Xk/RNwQp+dcRBJEZCmwBfhAVUvMOY8gdijkeS+LSaa0WwzUVdUTgTHAtIDjKQvi\n+pyLSBVgCnCTqv4SdDyRKiDuuD3nqrpfVVsCdYA0EWkedEyRiiD2Qp/3sphksoBjQj7X8doKu04Q\nCoxLVX/JueRV1XeACiJSvfhCjFq8nvMCxfM5F5EKuC/qF1V1aphV4vK8FxR3PJ/zHKq6E/gI6JZn\nUVye81D5xR7NeS+LSWYB0FBE6otIRaAP8Gaedd4ELvV6gZwC/Kyqm4o70DAKjF1EaoqIeO/TcP/G\n24s90sKL13NeoHg9515MTwOrVPXhfFaLu/MeSdxxfM6TRSTJe58IdAH+m2e1uDvnEFns0Zz38rEJ\nN36p6j4RuR6YieutNVFVV4rIIG/5E8A7uB4gq4HfgCuCijdUhLFfCFwjIvuAbKCPet1CgiQiL+N6\nplQXkQ3AnbgHi3F9ziGi2OPynAPtgP7Acu8+O8C/gLoQ1+c9krjj9ZzXAp4VkQTcF/Crqvp2Sfh+\nIbLYC33ereLfGGNMzJTF22XGGGOKiSUZY4wxMWNJxhhjTMxYkjHGGBMzlmSMMcbEjCUZY4wxMWNJ\nxhhjTMxYkjGlgjfPhYrI5cV4zOYisk9EuhTXMUsKETlfRPaISMOgYzHBsiRjTPQeBj5T1Q+CDiTe\nqOp0YDnwQNCxmGBZkjEmCiJyKm5sp/zGBDPwKNArnobhN8XPkowx0bkW2IYbh8qENxU3NtegoAMx\nwbEkY0o1EakuImNF5AfvGcEP3udqYdatJyJTROQX7zXda1svIh+HrFce6AnMUtW9YfYz2ns+VFdE\nRorIOhHJFpFFInJaTH/hOOINCT8XN6iiKaPK3CjMpuwQkSOAecDxwETchEupwDVAJxFJ86b3xUs6\nc4EawBO4KX9PBz4GKufZdWugCvBlPodOBX7GzeP+NTAaSAZuAaaISJ1wyamU+hzoKiInqGreIe9N\nGWBJxpRmQ4GGwHWqOi6n0Rs+/nFv+e1e8zDc5FH9VPVFr228iDwIpOfZb1Pv55p8jtsSOAK4UVWf\nCzlueeBWoB7wbZS/U0mTc46acfC8KqYMsNtlpjTrBWwFJuRpf9Jr7xXSdi6wCXg5z7qjw+w32fu5\nI+8CETkWOAqYEZpgPH94P7MLjDwOeHO431jE3eRMaHV0UeMxJZMlGVOa1QcyVXVfaKP3+RugQZ51\nV6vqgTzrbgF25tlvziRMEuaYqd7PV8Isaw7sIs6m2s2Pqp6tqo8BeM+lonm2knOObOKqMsqSjDGF\nt9X7eVSYZS29n/PDLGsNLImTGRyLS8452nrItUypZUnGlGZrgcbes5A/eZ8bectzrAeOF5FyedY9\nGkjKs98V3s9w1ew5D/1zPa/x5k4/Dtf5IKftLyLyuIh85/VmWyAix+QcV0Qmi8gWEdkgIo+ISKWQ\nbdeLyK0i8oWI7BaR2V5PulEisl1EvheR86Jd39vmYxG5RURew019/LyI/Coik7zl//Ri3+Vtf1OY\n83F8nnNmyhhLMqY0m4Z7fnJVnvZ/eO1vhLS9hZvjvG+edW8Js98lwC/AKWGWpQKLw1yttPJ+Lg5p\nm4T7Ej4Vl8gG8r/nNTnPho4D0nDz3t+fZ599gItxPeIOx109/Rf3/OM+4CkRqVCE9QFQ1YuA74H+\nqlpFVS8XkUbeNt1Utar3+80Jcz5OATaramaYZaYMsCRjSrMHcb24xorIBBG5RkQm4HqWZXrLczwA\nbASeEZFHvXVfAv6GK7r8M2mo6n5coWFnETksp93rBn0MsChMLLmSjIjUwHU8GKSqG1X1gKouUdVt\nIpICdAKGqOouVd0I3AlcnmefT6jqd149ypvAPlV92ovvZVwirVuE9Q9lH+55SzMROVxVt6lqaAJF\nRKrguoG/FuE+TSlkScaUWqr6M+4K4EmgO/CY9/MJ4LScGhlv3W3AacDbwABc0qmK+7IXDu4RNh53\n9dEjpC3nof9iDtYaV/2e0433WNyX/Pow69bxloV2EFgLHCkih4e0bQ55/xvwY57PeL9DtOvnS1XX\nAv1xIx/8KCIfikhantUuwF0xPRnJPk3pZHUyplRQ1Y8J09tLVbfivgivjWAf64DeoW3e1Uk13O2i\n0HW/FJGZwE3AFK9tVrgYvGV5b8N9B5QXkXphEs0Gb1lKSKKpB/ykqr8RjAN5G1T1deB171nRUOB1\ncl8JDQbeUFV7HlOG2ZWMMR4RSQzTnOH9DDfS8s3AqSJyVmGPpaqbgem4W3m1RKSciKSKSDUvsXwE\njBaRKiJSC7gbeLawx/HRZtzzIQBEpLGInOWdsz3Ar8D+kOU9cV22hxV3oCa+2JWMMf/zjoh8h7vd\nVQ7ojLsdNg/XiSAXVV1J0f4bugx3W24B8BfcUDYXeMv+DowB1uG+xKfgRgsIyn3AGBEZ7sXyCC7x\nNcM9r1pJSKcJVZ0GVAwgThNnpGx12TcmfyJyM3Ap7tZUIu621VTg7tDnN8aYyFmSMcYYEzP2TMYY\nY0zMWJIxxhgTM5ZkjDHGxIwlGWOMMTFjScYYY0zMWJIxxhgTM5ZkjDHGxIwlGWOMMTHz/65Zy4y+\n04EMAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x1142c8128>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "lm = modeling.models.Linear1D()\n",
+    "fitmod = modeling.fitting.LinearLSQFitter()(lm, bincens, lns)\n",
+    "\n",
+    "plt.scatter(bincens, lns)\n",
+    "plt.plot(bincens, fitmod(bincens), c='r', label=\"log-slope={:.2f}\".format(fitmod.slope.value))\n",
+    "plt.xlabel(r'$\\log(n_{\\rm commits})$', fontsize=18)\n",
+    "plt.ylabel(r'$\\log(n_{\\rm commiters})$', fontsize=18)\n",
+    "plt.legend()\n",
+    "\n",
+    "fitmod"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Seems to be a fairly good power-law slope... Zipf's law of random human stuff following power laws seems to hold?"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [default]",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This adds some quick experiments I did to see the commit distributions in the astropy repo (you can see the rendred notebook [here](https://github.com/eteq/astropy-tools/blob/contributor_commit_distributions/visualizations_demographics/contributor%20commit%20distributions.ipynb)).

It's formatted as a Jupyter notebook... Which raises a question: do we want to allow notebooks here?  I think it makes sense, but we have to be sure it doesn't blow up too much due to embedded plots (this one is just 33K so should be fine).  What do you think @astrofrog @bsipocz @adrn?