### PR TITLE
Stop checking consistency of pre-4.0 releases, close 4.2.x branch and add a manual backport

### DIFF
--- a/.github/workflows/pr_consistency.yml
+++ b/.github/workflows/pr_consistency.yml
@@ -41,5 +41,8 @@ jobs:
       run: python 4.check_consistency.py > output/index.html
     - name: Deploy 🚀
       uses: JamesIves/github-pages-deploy-action@v4
+      if: ${{ github.ref == 'refs/heads/main' }}
       with:
         folder: pr_consistency/output # The folder the action should deploy.
+        # Use _astropy in following in case we set this up for other repos in future
+        target-folder: pr_consistency_astropy

--- a/.github/workflows/pr_consistency.yml
+++ b/.github/workflows/pr_consistency.yml
@@ -23,6 +23,8 @@ jobs:
     - name: Get merged PRs
       working-directory: pr_consistency
       run: python 1.get_merged_prs.py
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Find PR branches
       working-directory: pr_consistency
       run: python 2.find_pr_branches.py

--- a/.github/workflows/pr_consistency.yml
+++ b/.github/workflows/pr_consistency.yml
@@ -28,9 +28,18 @@ jobs:
     - name: Find PR branches
       working-directory: pr_consistency
       run: python 2.find_pr_branches.py
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Find PR changelog section
       working-directory: pr_consistency
       run: python 3.find_pr_changelog_section.py
+    - name: Prepare output folder
+      working-directory: pr_consistency
+      run: mkdir output
     - name: Check consistency
       working-directory: pr_consistency
-      run: python 4.check_consistency.py
+      run: python 4.check_consistency.py > output/index.html
+    - name: Deploy 🚀
+      uses: JamesIves/github-pages-deploy-action@v4
+      with:
+        folder: pr_consistency/output # The folder the action should deploy.

--- a/.github/workflows/pr_consistency.yml
+++ b/.github/workflows/pr_consistency.yml
@@ -1,5 +1,8 @@
 name: Run PR changelog consistency check scripts
 on:
+  schedule:
+    # run every day at 4am UTC
+    - cron: '0 4 * * *'
   push:
     branches:
     - main

--- a/.github/workflows/pr_consistency.yml
+++ b/.github/workflows/pr_consistency.yml
@@ -1,0 +1,34 @@
+# GitHub Actions workflow for auto-inviting org members to human intervention.
+#
+# The file coordinate_package_policies.json contains the thresholds for
+# triggering addition for each of the coordinated packages.
+
+name: Run PR changelog consistency check scripts
+on:
+  push:
+    branches:
+    - main
+    tags:
+    - '*'
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - name: Install dependencies
+      run: pip install requests astropy
+    - name: Get merged PRs
+      working-directory: pr_consistency
+      run: python 1.get_merged_prs.py
+    - name: Find PR branches
+      working-directory: pr_consistency
+      run: python 2.find_pr_branches.py
+    - name: Find PR changelog section
+      working-directory: pr_consistency
+      run: python 3.find_pr_changelog_section.py
+    - name: Check consistency
+      working-directory: pr_consistency
+      run: python 4.check_consistency.py

--- a/.github/workflows/pr_consistency.yml
+++ b/.github/workflows/pr_consistency.yml
@@ -1,8 +1,3 @@
-# GitHub Actions workflow for auto-inviting org members to human intervention.
-#
-# The file coordinate_package_policies.json contains the thresholds for
-# triggering addition for each of the coordinated packages.
-
 name: Run PR changelog consistency check scripts
 on:
   push:

--- a/.github/workflows/pr_consistency.yml
+++ b/.github/workflows/pr_consistency.yml
@@ -3,9 +3,8 @@ on:
   push:
     branches:
     - main
-    tags:
-    - '*'
   pull_request:
+  workflow_dispatch:
 
 jobs:
   check:

--- a/common.py
+++ b/common.py
@@ -1,3 +1,4 @@
+import os
 import netrc
 import getpass
 import warnings
@@ -21,6 +22,10 @@ BRANCHES_DICT = {'astropy/astropy': ['v0.1.x', 'v0.2.x', 'v0.3.x', 'v0.4.x',
 
 def get_credentials(username=None, password=None, needs_token=False):
     pwtype = 'personal access token' if needs_token else 'password'
+
+    if needs_token and 'GITHUB_TOKEN' in os.environ:
+        print('Using GITHUB_TOKEN environment variable')
+        return None, os.environ['GITHUB_TOKEN']
 
     try:
         my_netrc = netrc.netrc()

--- a/pr_consistency/2.find_pr_branches.py
+++ b/pr_consistency/2.find_pr_branches.py
@@ -26,7 +26,7 @@ print("The repository this script currently works with is '{}'.\n"
       .format(REPOSITORY_NAME))
 
 
-REPOSITORY = f'git://github.com/{REPOSITORY_NAME}.git'
+REPOSITORY = f'https://github.com/{REPOSITORY_NAME}.git'
 NAME = os.path.basename(REPOSITORY_NAME)
 
 DIRTOCLONEIN = tempfile.mkdtemp()  # set this to a non-temp directory to retain the clone between runs

--- a/pr_consistency/4.check_consistency.py
+++ b/pr_consistency/4.check_consistency.py
@@ -16,9 +16,9 @@ def parse_isoformat(string):
     return datetime.strptime(string, "%Y-%m-%dT%H:%M:%S")
 
 
-# Only consider PRs merged after this date/time. At the moment, this is the
-# date and time at which the v1.0.x branch was created.
-START = parse_isoformat('2015-01-27T16:22:59')
+# Only consider PRs merged after this date/time - adjust this if you want to
+# check for consistency further in the past.
+START = parse_isoformat('2020-01-01T00:00:00')
 
 # The following option can be toggled to show only pull requests with issues or
 # show all pull requests.
@@ -67,10 +67,10 @@ BRANCH_CLOSED_DICT = {'astropy/astropy': {
                           'v3.0.x': parse_isoformat('2018-10-18T16:00:00'),
                           'v3.1.x': parse_isoformat('2019-04-15T16:00:00'),
                           'v3.2.x': parse_isoformat('2019-11-10T16:00:00'),
-                          'v4.0.x': None,
+                          'v4.0.x': parse_isoformat('2021-10-29T16:00:00'),
                           'v4.1.x': parse_isoformat('2020-11-25T06:46:46'),
-                          'v4.2.x': None,
-                          'v4.3.x': None,
+                          'v4.2.x': parse_isoformat('2021-04-01T16:00:00'),
+                          'v4.3.x': parse_isoformat('2021-10-29T16:00:00'),
                           'v5.0.x': None,
                           'v5.1.x': None, },
                       }
@@ -112,6 +112,7 @@ MANUAL_MERGES_DICT = {
                         '11401': ('v4.2.x'),
                         '11250': ('v4.2.x'),
                         '9183': ('v4.3.x'),
+                        '11724': ('v4.0.x'),
                     },
     'astropy/astropy-helpers': {'205': ('v1.1.x', 'v1.2.x', 'v1.3.x', 'v2.0.x',
                                         'v3.0.x', 'v3.1.x', 'v3.2.x', 'v4.0.x'),


### PR DESCRIPTION
Just some small updates when working on 4.0.6