### PR TITLE
Add script for adding contributors

### DIFF
--- a/.github/workflows/update_org_members.yml
+++ b/.github/workflows/update_org_members.yml
@@ -3,7 +3,7 @@
 # The file coordinate_package_policies.json contains the thresholds for
 # triggering addition for each of the coordinated packages.
 
-name: Invite organzation members based on merged PRs
+name: Invite organization members based on merged PRs
 
 on:
   schedule:

--- a/.github/workflows/update_org_members.yml
+++ b/.github/workflows/update_org_members.yml
@@ -7,7 +7,7 @@ name: Invite organzation members based on merged PRs
 
 on:
   schedule:
-    # Run once a day at 22:14 UTC
+    # Run once a day at 22:14 UTC (arbitrary time)
     - cron: '14 22 * * *'
 
 jobs:

--- a/.github/workflows/update_org_members.yml
+++ b/.github/workflows/update_org_members.yml
@@ -23,6 +23,6 @@ jobs:
 
     - name: Perform copy
       env:
-        ORG_INVITE_TOKEN: ${{ secrets.ORG_INVITE_TOKEN }}
+        ORG_INVITE_TOKEN: ${{ secrets.ORG_INVITE_TOKEN }} # this token needs "write:org" and maybe "repo:invite" or "admin:org" permissions TODO: fix this with the right answer once it's tested
       run: |
         python add_contributors_to_org.py --dry-run --verbose coordinated_package_policies.json

--- a/.github/workflows/update_org_members.yml
+++ b/.github/workflows/update_org_members.yml
@@ -1,0 +1,28 @@
+# GitHub Actions workflow for auto-inviting org members to human intervention.
+#
+# The file coordinate_package_policies.json contains the the thresholds for
+# triggering addition for each of the coordinate packages.
+
+name: Invite organzation members based on merged PRs
+
+on:
+  schedule:
+    # Run once a day at 22:14 UTC
+    - cron: '14 22 * * *'
+
+jobs:
+  invite_members:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-python@v2
+
+    - name: Install dependencies
+      run: pip install github3.py
+
+    - name: Perform copy
+      env:
+        BINSTAR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        python add_contributors_to_org.py --dry-run --verbose coordinated_package_policies.json

--- a/.github/workflows/update_org_members.yml
+++ b/.github/workflows/update_org_members.yml
@@ -1,6 +1,6 @@
 # GitHub Actions workflow for auto-inviting org members to human intervention.
 #
-# The file coordinate_package_policies.json contains the the thresholds for
+# The file coordinate_package_policies.json contains the thresholds for
 # triggering addition for each of the coordinate packages.
 
 name: Invite organzation members based on merged PRs

--- a/.github/workflows/update_org_members.yml
+++ b/.github/workflows/update_org_members.yml
@@ -1,7 +1,7 @@
 # GitHub Actions workflow for auto-inviting org members to human intervention.
 #
 # The file coordinate_package_policies.json contains the thresholds for
-# triggering addition for each of the coordinate packages.
+# triggering addition for each of the coordinated packages.
 
 name: Invite organzation members based on merged PRs
 

--- a/.github/workflows/update_org_members.yml
+++ b/.github/workflows/update_org_members.yml
@@ -23,6 +23,6 @@ jobs:
 
     - name: Perform copy
       env:
-        BINSTAR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ORG_INVITE_TOKEN: ${{ secrets.ORG_INVITE_TOKEN }}
       run: |
         python add_contributors_to_org.py --dry-run --verbose coordinated_package_policies.json

--- a/add_contributors_to_org.py
+++ b/add_contributors_to_org.py
@@ -1,0 +1,145 @@
+from argparse import ArgumentParser
+from datetime import date, datetime
+import os
+
+# Package name is github3.py
+import github3
+
+
+def main(token, repo, args,
+         verbose=False, dry_run=False, n_min_pr=1,
+         oldest_date=None):
+    """
+    Get list of contributors to a repository that are not currently
+    members of the Astropy GitHub organization and send them an
+    invitation to join the organization.
+
+    Contributor here means someone who has had a pull request merged.
+
+    Parameters
+    ----------
+
+    token : str
+        A GitHub token with adequate permissions to send invitations to
+        the Astropy GitHub organization.
+
+    repo : str
+        Name of a repository in the Astropy organization to check for
+        contributors.
+    """
+
+    g = github3.login(token=token)
+
+    astropy_org_repo = g.repository('astropy', repo)
+    astropy_org = g.organization('astropy')
+
+    already_tried = []
+
+    not_in = []
+
+    pr_count = {}
+
+    if oldest_date is not None:
+        too_old = oldest_date
+    else:
+        # Go back one year from now
+        now = datetime.now()
+        too_old = date(now.year - 1, now.month, now.day)
+
+    # By default PRs are returned sorted in descending order by date
+    # of creation.
+    for pr in astropy_org_repo.pull_requests(state='closed'):
+        if pr.created_at.date() < date(2019, 12, 31):
+            print("Too old, breaking...")
+            break
+
+        author = pr.user.login
+
+        if (author in already_tried):
+            pr_count[author] += 1
+            continue
+        elif (author == 'ghost'):
+            # ghost is the login for any user who has deleted their account
+            continue
+
+        pr_count[author] = 1
+
+        if verbose:
+            print(f"Checking {author}")
+
+        if not astropy_org.is_member(author):
+            if verbose:
+                print(author)
+            not_in.append(author)
+        else:
+            if verbose:
+                print(f"Already member: {author}")
+
+        already_tried.append(author)
+
+    print(not_in)
+
+    to_add = []
+    for author in not_in:
+        if verbose:
+            print(f"{author} has {pr_count[author]} PRs")
+        if pr_count[author] >= n_min_pr:
+            to_add.append(author)
+
+    to_add = sorted(to_add)
+
+    for person in to_add:
+        gh = g.user(person)
+        print(f"Name: {gh.name} GitHub login:{person}")
+
+    for person in to_add:
+        if verbose:
+            print(f"adding {person} to astropy org...")
+        if not dry_run:
+            astropy_org.add_or_update_membership(person, role='member')
+        else:
+            print(f'dry run: would have invited {person}')
+
+
+if __name__ == '__main__':
+
+    description = ('Check for contributors to astropy packages'
+                   ' who are not in the astropy GitHub'
+                   ' organization and send them an invitation.\n'
+                   'Set the environment variable GITHUB_TOKEN to a valid'
+                   ' GitHub token with permission to send invitations'
+                   ' to the organization.')
+
+    parser = ArgumentParser(description=description)
+
+    parser.add_argument('repo',
+                        help='Name of repository in the astropy GitHub '
+                             'organization to check for contributors '
+                             'who are not yet members of the organization')
+
+    parser.add_argument('--num-pr', '-n', action='store', default=2, type=int,
+                        help='Minimum number of merged PRs contributor must '
+                              'have to be added to organization.')
+
+    parser.add_argument('--date', '-d', type=date.fromisoformat,
+                        help='Only consider pull requests made after this '
+                             'date. Default is one year from date script '
+                             ' is run.')
+
+    parser.add_argument('--dry-run',, action='store_true',
+                        help='Run the script but do not actually send'
+                             ' any invitations.')
+
+    parser.add_argument('--verbose', '-v', action='store_true',
+                        help='Display more output while running.')
+    args = parser.parse_args()
+
+    print(args)
+
+    token = os.getenv('GITHUB_TOKEN', None)
+    if token is None:
+        raise RuntimeError('You need to set a GitHub token for this script'
+                           ' to work. If you want to see what the script would'
+                           ' do without sending invitations use the --dry-run'
+                           ' option.')
+    main(token, args.repo, )

--- a/add_contributors_to_org.py
+++ b/add_contributors_to_org.py
@@ -119,6 +119,7 @@ def process_invites_for_repo(token, repo,
     g = github3.login(token=token)
     astropy_org_repo = g.repository('astropy', repo)
     astropy_org = g.organization('astropy')
+    astropy_blocked = [b.login for b in astropy_org.blocked_users()]
 
     already_tried = []
 
@@ -150,6 +151,8 @@ def process_invites_for_repo(token, repo,
 
         if (author in already_tried):
             pr_count[author] += 1
+            continue
+        elif (author in astropy_blocked):
             continue
         elif (author == 'ghost'):
             # ghost is the login for any user who has deleted their account

--- a/add_contributors_to_org.py
+++ b/add_contributors_to_org.py
@@ -119,7 +119,10 @@ def process_invites_for_repo(token, repo,
     g = github3.login(token=token)
     astropy_org_repo = g.repository('astropy', repo)
     astropy_org = g.organization('astropy')
+
+    # Build lists of a couple of categories we should skip invites for
     astropy_blocked = [b.login for b in astropy_org.blocked_users()]
+    astropy_open_invitiation = [i.login for i in astropy_org.invitations()]
 
     already_tried = []
 
@@ -153,6 +156,8 @@ def process_invites_for_repo(token, repo,
             pr_count[author] += 1
             continue
         elif (author in astropy_blocked):
+            continue
+        elif (author in astropy_open_invitiation):
             continue
         elif (author == 'ghost'):
             # ghost is the login for any user who has deleted their account

--- a/add_contributors_to_org.py
+++ b/add_contributors_to_org.py
@@ -297,7 +297,7 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    token = os.getenv('GITHUB_TOKEN', None)
+    token = os.getenv('ORG_INVITE_TOKEN', None)
     if token is None:
         raise RuntimeError('You need to set a GitHub token for this script'
                            ' to work. If you want to see what the script would'

--- a/coordinated_package_policies.json
+++ b/coordinated_package_policies.json
@@ -1,0 +1,7 @@
+{
+    "ccdproc": {
+        "min_merged_prs": 1,
+        "only_prs_since": "2018-01-01",
+        "min_time_between_invites_days": 180
+    }
+}

--- a/coordinated_package_policies.json
+++ b/coordinated_package_policies.json
@@ -3,5 +3,10 @@
         "min_merged_prs": 1,
         "only_prs_since": "2018-01-01",
         "min_time_between_invites_days": 180
+    },
+    "ccd-reduction-and-photometry-guide": {
+        "min_merged_prs": 1,
+        "only_prs_since": "2018-01-01",
+        "min_time_between_invites_days": 180
     }
 }


### PR DESCRIPTION
The intent of this is to semi-automate adding people who have had PRs merged in coordinated packages (or astropy core) added to the astropy organization so that coordinated package maintainers can assign them to issues, etc.

To do before merging:

- [x] Add github token to this repo's secrets.
- [x] Add logic to check whether person has an open invitation.
- [x] Add logic to check for blocked users before sending invite (unless github already does that, not sure).