### PR TITLE
Add scripts for checking and modifying the astropy .mailmap file

### DIFF
--- a/mailmap_check.py
+++ b/mailmap_check.py
@@ -1,0 +1,65 @@
+"""
+This script finds all authors that have committed to the Astropy core package
+and compares against the .mailmap file in the core package repository. This
+only checks whether emails in the git commit author list are present in the
+mailmap or not, and prints name/email pairs for any missing emails.
+
+Usage:
+
+    python mailmap_check.py <astropy repo path>
+"""
+
+# Standard library
+import pathlib
+import sys
+
+# Third-party
+import astropy.table as at
+from git import Repo
+
+if len(sys.argv) != 2:
+    raise ValueError(
+        "Pass in a single command-line argument: the path to the cloned "
+        "astropy core repository"
+    )
+
+astropy_repo_path = pathlib.Path(sys.argv[1])
+if not astropy_repo_path.exists():
+    raise RuntimeError(f"Astropy repo path does not exist {astropy_repo_path}")
+
+mailmap_path = astropy_repo_path / '.mailmap'
+repo = Repo(astropy_repo_path)
+
+all_authors = []
+for commit in repo.iter_commits():
+    all_authors.append({
+        'name': commit.author.name.strip(),
+        'email': commit.author.email.strip().lower()
+    })
+all_authors = at.Table(all_authors)
+all_authors = at.unique(all_authors, keys='email')
+
+mailmap_path = astropy_repo_path / '.mailmap'
+
+email_to_name = {}
+with open(mailmap_path, 'r') as f:
+    for line in f:
+        name, *name_emails = [
+            x.replace('<', '').replace('>', '').strip()
+            for x in line.split('<')
+        ]
+        name_emails = [x.lower() for x in name_emails]
+
+        for _email in name_emails:
+            if _email in email_to_name and name != email_to_name[_email]:
+                raise ValueError(f"name: {name}, email: {_email}")
+            email_to_name[_email] = name
+
+missing_authors = []
+for author in all_authors:
+    if author['email'] not in email_to_name:
+        missing_authors.append(dict(author))
+missing_authors = at.Table(missing_authors)
+missing_authors.sort('name')
+for author in missing_authors:
+    print(f"{author['name']: <29}<{author['email']}>")

--- a/mailmap_sort.py
+++ b/mailmap_sort.py
@@ -1,0 +1,40 @@
+"""
+This script sorts a .mailmap file by name and email. This is meant to be used
+with the mailmap_check.py script when updating the .mailmap file.
+
+Usage:
+
+    python mailmap_sort.py <mailmap path>
+"""
+
+# Standard library
+import pathlib
+import sys
+
+# Third-party
+import numpy as np
+
+
+if len(sys.argv) != 2:
+    raise ValueError(
+        "Pass in a single command-line argument: the path to the mailmap file"
+    )
+
+mailmap_path = pathlib.Path(sys.argv[1])
+if not mailmap_path.exists():
+    raise RuntimeError(f"Mailmap path does not exist {mailmap_path}")
+
+sortable = []
+with open(mailmap_path, 'r') as f:
+    lines = [x.strip() for x in f.readlines()]
+    for line in lines:
+        name, *name_emails = [
+            x.replace('<', '').replace('>', '').strip()
+            for x in line.split('<')
+        ]
+        name_emails = [x.lower() for x in name_emails]
+        name = f"{name}{len(name_emails)} " + " ".join(name_emails)
+        sortable.append(name)
+
+for line in np.array(lines)[np.argsort(sortable)]:
+    print(line)


### PR DESCRIPTION
This adds two scripts: one to find astropy/astropy committers that are missing from the astropy core .mailmap file, and one to sort the .mailmap file. They could be combined, but I found that this couldn't be fully automated (some by-eye vetting needed to be done to associate names) and so it was easier to have this as two separate scripts.

I needed to update the .mailmap file before generating some figures that summarize information about astropy/astropy committers for the astropy v5.0 paper.