### PR TITLE
Automatically invite contributors to coordinated packages to Astropy GitHub org

### DIFF
--- a/.github/workflows/update_org_members.yml
+++ b/.github/workflows/update_org_members.yml
@@ -30,4 +30,4 @@ jobs:
         REPOS: "asdf-astropy astropy astropy-healpix astroquery ccdproc photutils regions reproject specreduce specutils"
         OTHER_BOTS: "meeseeksmachine"  # Accounts that end [bot] are already filtered out
       run: |
-        python add_contributors_to_org.py --dry-run --other-bots $OTHER_BOTS --verbose astropy $REPOS
+        python add_contributors_to_org.py --other-bots $OTHER_BOTS --verbose astropy $REPOS


### PR DESCRIPTION
This pull request is the last step in implementing a bot that will send invitations to contributors to coordinate packages that have had at least one pull request merged. 

The actual code is at https://github.com/astropy/astropy-tools/blob/main/add_contributors_to_org.py

A recent run of this as a github action is here: https://github.com/astropy/astropy-tools/runs/7235474185?check_suite_focus=true

This closes #170 which tracks outstanding to-dos after the initial draft of the bot code.

## Overview of what this bot does

- Periodically (currently daily) check pull requests merged in an Astropy coordinated package (see list [here](https://github.com/astropy/astropy-tools/blob/main/.github/workflows/update_org_members.yml#L30)) for PR authors who are not in the Astropy GitHub organization.
- If the person is not in the organization, does not have a pending invitation, is neither blocked by the org nor a bot, has not declined an invitation, and has not been invited for some time (currently 365 days) then an invitation to join the astropy GitHub organization is sent.
- This neither increases nor decreases the amount of documentation we have now for who is added to the organization -- right now requests to add people are handled on an ad hoc basis by the CoCo.

## Motivation for the bot

Maintainers of repositories that are part of the astropy organization (as the coordinated packages are) cannot add  a person as a team member for their repo or assign them reviews or anything else until that person is a member of the astropy github organization. GitHub's permission structure for organization management is very course. People are either members of the organization (with limited authority to make changes) or owners of the organization (with the power to make any and all changes to the organization).

This bot provides a work-around. Coordinated package maintainers do their usual review/merge of pull requests. The bot runs once a day, looking for merged pull requests by people who are not in the astropy organization. If it finds any, the bot has GitHub send them an invite to join the organization.

If they accept, they are added to the organization as members.

Once that is done, coordinate package maintainers should be able to add those folks to teams in their packages on GitHub.

## Current bot settings which could be changed:

- Minimum time between invitations sent by GitHub: 365 days
    + Why: Don't want the bot to be a pest.
- Minimum number of merged PRs before sending an org invite: 1
    + Why: They made a contribution, let's encourage more by sending the invite! Remember, this does NOT add them to any team in any repo. It just invites them to the org.
- Oldest PR to examine for invitations: 1 year
    + Why: Seemed like a reasonable time....requests to add folks to the org can still be sent to the CoCo if needed.
- Repostiories included: Astropy coordinated packages from https://www.astropy.org/affiliated/index.html#coordinated-package-list
    + Why: Only repos in the astropy org need this, and the coordinated packages seemed like a sensible bnoundary.