### PR TITLE
MNT: Replace master with main in pr_consistency

### DIFF
--- a/pr_consistency/1.get_merged_prs.py
+++ b/pr_consistency/1.get_merged_prs.py
@@ -1,5 +1,5 @@
 # The purpose of this script is to download information about all pull
-# requests merged into the master branch of the given repository. This
+# requests merged into the main branch of the given repository. This
 # information is downloaded to a JSON file.
 
 import os

--- a/pr_consistency/3.find_pr_changelog_section.py
+++ b/pr_consistency/3.find_pr_changelog_section.py
@@ -31,7 +31,7 @@ if os.environ.get('LOCAL_CHANGELOG'):
     with open(CHANGELOG) as f:
         changelog_lines = f.readlines()
 else:
-    CHANGELOG = f'https://raw.githubusercontent.com/{REPOSITORY}/master/{CHANGELOG_NAME}'
+    CHANGELOG = f'https://raw.githubusercontent.com/{REPOSITORY}/main/{CHANGELOG_NAME}'
     changelog_lines = requests.get(CHANGELOG).text.splitlines()
 
 TMPDIR = tempfile.mkdtemp()


### PR DESCRIPTION
Much smaller scope than #158 and should be uncontroversial.

The other occurrences happen in files that I want to get rid of anyway.

Close #157